### PR TITLE
chore(deps): bump to latest stable major versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,12 +383,13 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
 dependencies = [
  "arc-swap",
  "bytes",
+ "either",
  "fs-err",
  "http",
  "http-body",
@@ -396,7 +397,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "axum-test"
-version = "19.1.1"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a28640adad0e99978d38bc455b323c62a5cddc4e22f83eacde93f8c395ae7e3"
+checksum = "43c6a2f1d97ee33c39f13dacc0f84ae781a9c2ed373a75bad1129094f5a7c4bd"
 dependencies = [
  "anyhow",
  "axum",
@@ -1133,7 +1133,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -1639,20 +1638,11 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
+ "hmac",
 ]
 
 [[package]]
@@ -2483,7 +2473,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror",
  "tokio",
  "tracing",
@@ -2566,7 +2556,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "strum",
  "tempfile",
  "thiserror",
@@ -2592,7 +2582,7 @@ dependencies = [
  "clap",
  "hex",
  "hipstr",
- "hmac 0.12.1",
+ "hmac",
  "jiff",
  "reqwest 0.13.4",
  "reqwest-middleware",
@@ -2601,7 +2591,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "strum",
  "thiserror",
  "tokio",
@@ -2884,7 +2874,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac 0.13.0",
+ "hmac",
  "md-5 0.11.0",
  "memchr",
  "rand 0.10.1",
@@ -3444,15 +3434,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,16 +59,15 @@ reqwest-tracing = { version = "0.7", features = [] }
 # HTTP server
 axum = { version = "0.8", features = [] }
 axum-client-ip = { version = "1.3", features = ["serde"] }
-axum-server = { version = "0.7", features = ["tls-rustls"] }
+axum-server = { version = "0.8", features = ["tls-rustls"] }
 axum-extra = { version = "0.12", features = [] }
-axum-test = { version = "19.1", features = [] }
+axum-test = { version = "20.1", features = [] }
 tower = { version = "0.5", features = ["full"] }
 tower-http = { version = "0.6", features = ["full"] }
 
 # OpenAPI/Documentation
 aide = { version = "0.15", features = ["axum", "macros", "scalar"] }
 schemars = { version = "0.9", features = ["uuid1", "jiff02"] }
-jsonschema = { version = "0.29", features = [] }
 
 # Authentication
 jsonwebtoken = { version = "10.3", features = ["aws_lc_rs"] }
@@ -77,9 +76,9 @@ zxcvbn = { version = "3.1", features = ["serde"] }
 
 # Encryption & Cryptography
 chacha20poly1305 = { version = "0.10", features = [] }
-hkdf = { version = "0.12", features = [] }
-sha2 = { version = "0.10", features = [] }
-hmac = { version = "0.12", features = [] }
+hkdf = { version = "0.13", features = [] }
+sha2 = { version = "0.11", features = [] }
+hmac = { version = "0.13", features = [] }
 
 # Encoding
 base64 = { version = "0.22", features = [] }

--- a/crates/nvisy-webhook/src/reqwest/client.rs
+++ b/crates/nvisy-webhook/src/reqwest/client.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use jiff::Timestamp;
 use reqwest::Client;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};


### PR DESCRIPTION
## Summary

Updates all workspace dependencies to their latest **stable** versions. Pre-release majors are intentionally skipped.

### Bumped (stable majors)
| Crate | From → To | Notes |
|---|---|---|
| `axum-server` | 0.7 → 0.8 | no API changes |
| `axum-test` | 19.1 → 20.1 | dev-dep; tests compile clean |
| `sha2` | 0.10 → 0.11 | RustCrypto digest 0.11 |
| `hmac` | 0.12 → 0.13 | `new_from_slice` moved to the `KeyInit` trait — added the import in the webhook signer |
| `hkdf` | 0.12 → 0.13 | |
| `jsonschema` | _removed_ | declared in `Cargo.toml` but used by no crate |

The `digest` 0.11 generation was already in the tree via `argon2` and `postgres-protocol`, so this aligns our direct RustCrypto usage with it. The only code change required was a single import.

### Intentionally skipped (pre-release)
Everything else is already at its latest stable patch via `cargo update`. The remaining newer versions are pre-releases:
- `aide` 0.16.0-alpha (and the coupled `schemars` 1.x)
- `chacha20poly1305` 0.11.0-rc
- `diesel-derive-enum` 3.0.0-beta

### Verification
Locally green: `cargo check`, `clippy -D warnings`, `cargo +nightly fmt --check`, `cargo doc -D warnings`, test compilation, and `cargo deny check all`. The full test suite (needs Postgres + NATS) runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)