### PR TITLE
ci: run the security deny check daily

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ on:
       - "deny.toml"
       - ".github/workflows/security.yml"
   schedule:
-    - cron: "0 6 * * 1" # Weekly on Monday at 6 AM
+    - cron: "0 6 * * *" # Daily at 6 AM
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Bumps the scheduled `cargo deny check all` from weekly to daily.

New RUSTSEC advisories keep landing mid-week between a branch being cut and its CI run (three times in recent PRs). The weekly Monday cron leaves up to 7 days before main is re-checked; daily narrows that to ~24h.

```diff
-    - cron: "0 6 * * 1" # Weekly on Monday at 6 AM
+    - cron: "0 6 * * *" # Daily at 6 AM
```

Note: this shortens the exposure window on `main` but does not prevent branch-time races — only a required pre-merge re-run would. The push/PR triggers are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)