### PR TITLE
chore(deps): migrate schemars 0.9 → 1.0, aide 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,13 +29,13 @@ dependencies = [
 
 [[package]]
 name = "aide"
-version = "0.15.1"
+version = "0.16.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6966317188cdfe54c58c0900a195d021294afb3ece9b7073d09e4018dbb1e3a2"
+checksum = "390515b47251185fa076ac92a7a582d9d383b03e13cef0c801e7670cf928229b"
 dependencies = [
  "aide-macros",
  "axum",
- "axum-extra 0.10.3",
+ "axum-extra",
  "bytes",
  "cfg-if",
  "http",
@@ -52,11 +52,11 @@ dependencies = [
 
 [[package]]
 name = "aide-macros"
-version = "0.15.0"
+version = "0.16.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2a08f14808f3c46f3e3004b727bace64af44c3c5996d0480a14d3852b1b25a"
+checksum = "44db8ab6bd2a6748ce7c948a4813456bd95ec3bfdbe1635d52f4a0276d0fa4f0"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -317,28 +317,6 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "sync_wrapper",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-extra"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
-dependencies = [
- "axum",
- "axum-core",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "serde_core",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -903,6 +881,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +919,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +949,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -2368,7 +2380,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2606,7 +2618,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-client-ip",
- "axum-extra 0.12.6",
+ "axum-extra",
  "axum-test",
  "base64",
  "bigdecimal",
@@ -3552,15 +3564,16 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.9.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "indexmap",
  "jiff",
  "ref-cast",
  "schemars_derive",
+ "semver",
  "serde",
  "serde_json",
  "uuid",
@@ -3568,9 +3581,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.9.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3708,15 +3721,15 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "0.14.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b417bedc008acbdf6d6b4bc482d29859924114bbe2650b7921fb68a261d0aa6"
+checksum = "67d525c8ff68aa99e5818302259bdd02d86d0303710616f39c0f44846ff6d332"
 dependencies = [
  "axum",
- "futures",
+ "itoa",
  "percent-encoding",
+ "ryu",
  "serde",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,8 +68,8 @@ tower = { version = "0.5", features = ["full"] }
 tower-http = { version = "0.6", features = ["full"] }
 
 # OpenAPI/Documentation
-aide = { version = "0.15", features = ["axum", "macros", "scalar"] }
-schemars = { version = "0.9", features = ["uuid1", "jiff02"] }
+aide = { version = "0.16.0-alpha.4", features = ["axum", "macros", "scalar"] }
+schemars = { version = "1.0", features = ["uuid1", "jiff02", "semver1"] }
 
 # Authentication
 jsonwebtoken = { version = "10.3", features = ["aws_lc_rs"] }

--- a/crates/nvisy-server/src/extract/reject/form_with_rej.rs
+++ b/crates/nvisy-server/src/extract/reject/form_with_rej.rs
@@ -205,7 +205,7 @@ where
     fn inferred_early_responses(
         ctx: &mut GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<aide::openapi::StatusCode>, Response)> {
         Query::<T>::inferred_early_responses(ctx, operation)
     }
 }

--- a/crates/nvisy-server/src/extract/reject/json_with_rej.rs
+++ b/crates/nvisy-server/src/extract/reject/json_with_rej.rs
@@ -180,7 +180,7 @@ where
     fn inferred_early_responses(
         ctx: &mut GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, aide::openapi::Response)> {
+    ) -> Vec<(Option<aide::openapi::StatusCode>, aide::openapi::Response)> {
         axum::Json::<T>::inferred_early_responses(ctx, operation)
     }
 }
@@ -201,7 +201,7 @@ where
     fn inferred_responses(
         ctx: &mut GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, aide::openapi::Response)> {
+    ) -> Vec<(Option<aide::openapi::StatusCode>, aide::openapi::Response)> {
         AxumJson::<T>::inferred_responses(ctx, operation)
     }
 }

--- a/crates/nvisy-server/src/extract/reject/path_with_rej.rs
+++ b/crates/nvisy-server/src/extract/reject/path_with_rej.rs
@@ -178,7 +178,7 @@ where
     fn inferred_early_responses(
         ctx: &mut GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<aide::openapi::StatusCode>, Response)> {
         AxumPath::<T>::inferred_early_responses(ctx, operation)
     }
 }

--- a/crates/nvisy-server/src/extract/reject/query_with_rej.rs
+++ b/crates/nvisy-server/src/extract/reject/query_with_rej.rs
@@ -170,7 +170,7 @@ where
     fn inferred_early_responses(
         ctx: &mut GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<aide::openapi::StatusCode>, Response)> {
         AxumQuery::<T>::inferred_early_responses(ctx, operation)
     }
 }

--- a/crates/nvisy-server/src/extract/reject/validated_json.rs
+++ b/crates/nvisy-server/src/extract/reject/validated_json.rs
@@ -225,7 +225,7 @@ where
     fn inferred_early_responses(
         ctx: &mut GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<aide::openapi::StatusCode>, Response)> {
         Json::<T>::inferred_early_responses(ctx, operation)
     }
 }

--- a/crates/nvisy-server/src/extract/version.rs
+++ b/crates/nvisy-server/src/extract/version.rs
@@ -247,7 +247,7 @@ impl OperationInput for Version {
     fn inferred_early_responses(
         ctx: &mut GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<aide::openapi::StatusCode>, Response)> {
         Path::<VersionParams>::inferred_early_responses(ctx, operation)
     }
 }

--- a/crates/nvisy-server/src/handler/error/http_error.rs
+++ b/crates/nvisy-server/src/handler/error/http_error.rs
@@ -369,7 +369,7 @@ impl<'a> OperationOutput for Error<'a> {
     fn inferred_responses(
         _ctx: &mut GenContext,
         _operation: &mut Operation,
-    ) -> Vec<(Option<u16>, aide::openapi::Response)> {
+    ) -> Vec<(Option<aide::openapi::StatusCode>, aide::openapi::Response)> {
         // Return empty vec to prevent aide from adding a default 200 response.
         // Error responses should be explicitly documented via TransformOperation.
         Vec::new()


### PR DESCRIPTION
Unifies the workspace on **schemars 1.0** (bumping **aide** to `0.16.0-alpha.4`, the release that speaks schemars 1.0).

## Why
The runtime's `nvisy-schema` types (`Policy`, `Context`) derive schemars **1.0** `JsonSchema`. Our stack was on schemars **0.9** (via aide 0.15), so those types couldn't embed as typed fields in our OpenAPI endpoints — two incompatible `JsonSchema` traits. This unifies on 1.0 so the engine's config types slot straight into the upcoming policy/context endpoints with full OpenAPI schemas.

## Changes
- `aide` 0.15 → 0.16.0-alpha.4, `schemars` 0.9 → 1.0 (`+semver1` feature).
- aide 0.16 types `inferred_responses` / `inferred_early_responses` status keys as `openapi::StatusCode` instead of `u16` — updated the 8 impl signatures.
- The ~190 `#[derive(JsonSchema)]` sites migrated with **no changes**.

## Note
aide 0.16 is a **pre-release alpha** — accepted deliberately to get onto schemars 1.0 (see runtime integration work).

## Verification
Full workspace green: check, `clippy -D warnings`, `fmt --check`, `doc -D warnings`, and the full test suite (200+ tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)