### PR TITLE
chore(deps): drop nvisy-engine-core, use nvisy-engine re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "elide-bento"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#2f038ec0359527a8f223282b019a7bccaa78583d"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d93213295bd7cee417acb251c2260fa156fff7b9"
 dependencies = [
  "async-trait",
  "base64",
@@ -3708,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "nvisy-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#2f038ec0359527a8f223282b019a7bccaa78583d"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d93213295bd7cee417acb251c2260fa156fff7b9"
 dependencies = [
  "derive_builder",
  "derive_more",
@@ -3723,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "nvisy-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#2f038ec0359527a8f223282b019a7bccaa78583d"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d93213295bd7cee417acb251c2260fa156fff7b9"
 dependencies = [
  "derive_builder",
  "derive_more",
@@ -3739,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "nvisy-engine"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#2f038ec0359527a8f223282b019a7bccaa78583d"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d93213295bd7cee417acb251c2260fa156fff7b9"
 dependencies = [
  "bytes",
  "elide",
@@ -3793,7 +3793,7 @@ dependencies = [
 [[package]]
 name = "nvisy-policy"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#2f038ec0359527a8f223282b019a7bccaa78583d"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d93213295bd7cee417acb251c2260fa156fff7b9"
 dependencies = [
  "derive_more",
  "elide-core",
@@ -3838,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "nvisy-schema"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#2f038ec0359527a8f223282b019a7bccaa78583d"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d93213295bd7cee417acb251c2260fa156fff7b9"
 dependencies = [
  "bytes",
  "elide-core",
@@ -3879,7 +3879,6 @@ dependencies = [
  "jiff",
  "jsonwebtoken",
  "nvisy-base",
- "nvisy-core",
  "nvisy-engine",
  "nvisy-nats",
  "nvisy-postgres",
@@ -4203,7 +4202,7 @@ dependencies = [
  "nom 7.1.3",
  "once_cell",
  "postcard",
- "quick-xml 0.41.0",
+ "quick-xml 0.40.1",
  "regex",
  "regex-cache",
  "serde",
@@ -5844,7 +5843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ documentation = "https://docs.rs/nvisy-server"
 # Runtime crates
 nvisy-engine = { git = "https://github.com/nvisycom/runtime", branch = "main" }
 nvisy-schema = { git = "https://github.com/nvisycom/runtime", branch = "main", default-features = false }
-nvisy-engine-core = { package = "nvisy-core", git = "https://github.com/nvisycom/runtime", branch = "main", default-features = false }
 
 # Internal crates
 nvisy-base = { path = "./crates/nvisy-base", version = "0.1.0" }

--- a/crates/nvisy-server/Cargo.toml
+++ b/crates/nvisy-server/Cargo.toml
@@ -29,7 +29,6 @@ default = []
 [dependencies]
 # Runtime crates
 nvisy-engine = { workspace = true }
-nvisy-engine-core = { workspace = true }
 nvisy-schema = { workspace = true }
 
 # Internal crates

--- a/crates/nvisy-server/src/handler/runs.rs
+++ b/crates/nvisy-server/src/handler/runs.rs
@@ -469,7 +469,7 @@ fn serialize_error(error: serde_json::Error) -> Error<'static> {
 }
 
 /// Maps an engine analyze/anonymize failure to an internal error.
-fn analysis_error(error: nvisy_engine_core::Error) -> Error<'static> {
+fn analysis_error(error: nvisy_engine::Error) -> Error<'static> {
     ErrorKind::InternalServerError
         .with_message("Redaction engine failed")
         .with_context(error.to_string())

--- a/crates/nvisy-server/src/service/engine/mod.rs
+++ b/crates/nvisy-server/src/service/engine/mod.rs
@@ -9,8 +9,8 @@ use std::path::PathBuf;
 
 use derive_more::Deref;
 use nvisy_engine::Engine;
-use nvisy_engine_core::llm::LlmConfig;
-use nvisy_engine_core::ner::NerConfig;
+use nvisy_engine::llm::LlmConfig;
+use nvisy_engine::ner::NerConfig;
 use serde::{Deserialize, Serialize};
 
 use crate::{Error, Result};


### PR DESCRIPTION
## Summary

`nvisy-engine` now re-exports `Error`, `llm`, and `ner` from `nvisy-core`, so the separate `nvisy-engine-core` (`package = "nvisy-core"`) git dependency — added earlier only to reach those types — is no longer needed.

- Repointed the three usages to `nvisy_engine::{Error, llm::LlmConfig, ner::NerConfig}`.
- Removed `nvisy-engine-core` from the workspace + server manifests.
- Bumped the `nvisycom/runtime` git deps to latest `main` (the commit that added the re-exports).

`nvisy-core` remains in the lockfile as a transitive dep of `nvisy-engine`, as expected — it's just no longer a direct dependency of ours.

## Test plan
- `cargo check --all-features --workspace` ✅
- `cargo clippy --all-targets --all-features --workspace -- -D warnings` ✅
- `cargo +nightly fmt --all -- --check` ✅
- `cargo test --all-features --workspace` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)