### PR TITLE
OpenAPI null-stripping + route slash/naming cleanup

### DIFF
--- a/crates/nvisy-server/src/handler/authentication.rs
+++ b/crates/nvisy-server/src/handler/authentication.rs
@@ -293,8 +293,8 @@ pub fn routes() -> ApiRouter<ServiceState> {
     use aide::axum::routing::*;
 
     ApiRouter::new()
-        .api_route("/auth/login", post_with(login, login_docs))
-        .api_route("/auth/signup", post_with(signup, signup_docs))
-        .api_route("/auth/logout", post_with(logout, logout_docs))
+        .api_route("/auth/login/", post_with(login, login_docs))
+        .api_route("/auth/signup/", post_with(signup, signup_docs))
+        .api_route("/auth/logout/", post_with(logout, logout_docs))
         .with_path_items(|item| item.tag("Authentication"))
 }

--- a/crates/nvisy-server/src/handler/files.rs
+++ b/crates/nvisy-server/src/handler/files.rs
@@ -589,7 +589,7 @@ pub fn routes() -> ApiRouter<ServiceState> {
                 .delete_with(delete_file, delete_file_docs),
         )
         .api_route(
-            "/files/{fileId}/content",
+            "/files/{fileId}/content/",
             get_with(download_file, download_file_docs),
         )
         .with_path_items(|item| item.tag("Files"))

--- a/crates/nvisy-server/src/handler/members.rs
+++ b/crates/nvisy-server/src/handler/members.rs
@@ -397,7 +397,7 @@ pub fn routes() -> ApiRouter<ServiceState> {
             get_with(list_members, list_members_docs),
         )
         .api_route(
-            "/workspaces/{workspaceId}/members/leave",
+            "/workspaces/{workspaceId}/members/leave/",
             post_with(leave_workspace, leave_workspace_docs),
         )
         .api_route(

--- a/crates/nvisy-server/src/handler/monitors.rs
+++ b/crates/nvisy-server/src/handler/monitors.rs
@@ -117,6 +117,6 @@ pub fn routes() -> ApiRouter<ServiceState> {
     use aide::axum::routing::*;
 
     ApiRouter::new()
-        .api_route("/health", get_with(health_status, health_status_docs))
+        .api_route("/health/", get_with(health_status, health_status_docs))
         .with_path_items(|item| item.tag("Health"))
 }

--- a/crates/nvisy-server/src/handler/notifications.rs
+++ b/crates/nvisy-server/src/handler/notifications.rs
@@ -115,7 +115,7 @@ pub fn routes() -> ApiRouter<ServiceState> {
             get_with(list_notifications, list_notifications_docs),
         )
         .api_route(
-            "/notifications/unread",
+            "/notifications/unread/",
             get_with(get_unread_status, get_unread_status_docs),
         )
         .with_path_items(|item| item.tag("Notifications"))

--- a/crates/nvisy-server/src/handler/response/accounts.rs
+++ b/crates/nvisy-server/src/handler/response/accounts.rs
@@ -25,6 +25,7 @@ pub struct Account {
     /// Email address associated with the account.
     pub email_address: String,
     /// Company name (optional).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub company_name: Option<String>,
 
     /// Timestamp when the account was created.

--- a/crates/nvisy-server/src/handler/response/invites.rs
+++ b/crates/nvisy-server/src/handler/response/invites.rs
@@ -22,7 +22,8 @@ pub struct Invite {
     pub invite_id: Uuid,
     /// ID of the workspace the invitation is for.
     pub workspace_id: Uuid,
-    /// Email address of the invitee (null for open invite codes).
+    /// Email address of the invitee (omitted for open invite codes).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub invitee_email: Option<String>,
     /// Invite token (only included for open invitations without invitee_email).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -105,6 +106,7 @@ pub struct InvitePreview {
     /// Display name of the workspace.
     pub display_name: String,
     /// Description of the workspace.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Tags associated with the workspace.
     pub tags: Vec<String>,

--- a/crates/nvisy-server/src/handler/response/monitors.rs
+++ b/crates/nvisy-server/src/handler/response/monitors.rs
@@ -5,7 +5,7 @@ use nvisy_base::health::{ComponentHealth, HealthStatus};
 use schemars::JsonSchema;
 use serde::Serialize;
 
-/// Response body for `GET /health`.
+/// Response body for `GET /health/`.
 #[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Health {

--- a/crates/nvisy-server/src/handler/response/pipelines.rs
+++ b/crates/nvisy-server/src/handler/response/pipelines.rs
@@ -24,6 +24,7 @@ pub struct Pipeline {
     /// Pipeline name.
     pub name: String,
     /// Pipeline description.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Pipeline lifecycle status.
     pub status: PipelineStatus,
@@ -100,6 +101,7 @@ pub struct PipelineSummary {
     /// Pipeline name.
     pub name: String,
     /// Pipeline description.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Pipeline lifecycle status.
     pub status: PipelineStatus,

--- a/crates/nvisy-server/src/handler/response/tokens.rs
+++ b/crates/nvisy-server/src/handler/response/tokens.rs
@@ -77,7 +77,8 @@ pub struct ApiTokenWithJWT {
     pub session_type: ApiTokenType,
     /// Timestamp of token creation.
     pub issued_at: Timestamp,
-    /// Timestamp when the token expires (None = never expires).
+    /// Timestamp when the token expires (omitted = never expires).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expired_at: Option<Timestamp>,
     /// The JWT token string (only shown once on creation).
     pub token: String,

--- a/crates/nvisy-server/src/handler/response/webhooks.rs
+++ b/crates/nvisy-server/src/handler/response/webhooks.rs
@@ -33,6 +33,7 @@ pub struct Webhook {
     /// Current status of the webhook.
     pub status: WebhookStatus,
     /// Timestamp of the most recent webhook trigger.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub last_triggered_at: Option<Timestamp>,
     /// Account that originally created this webhook.
     pub created_by: Uuid,

--- a/crates/nvisy-server/src/handler/response/workspaces.rs
+++ b/crates/nvisy-server/src/handler/response/workspaces.rs
@@ -19,6 +19,7 @@ pub struct Workspace {
     /// Display name of the workspace.
     pub display_name: String,
     /// Description of the workspace.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Tags associated with the workspace.
     pub tags: Vec<String>,

--- a/crates/nvisy-server/src/handler/runs.rs
+++ b/crates/nvisy-server/src/handler/runs.rs
@@ -318,7 +318,7 @@ async fn get_pipeline_run_analysis(
 }
 
 fn get_pipeline_run_analysis_docs(op: TransformOperation) -> TransformOperation {
-    op.summary("Get run analysis")
+    op.summary("Get run detections")
         .description("Returns the run's detected findings (the analyzed document) for review.")
         .response::<200, Json<AnalyzedDocument>>()
         .response::<401, Json<ErrorResponse>>()
@@ -492,11 +492,11 @@ pub fn routes() -> ApiRouter<ServiceState> {
             get_with(get_pipeline_run, get_pipeline_run_docs),
         )
         .api_route(
-            "/runs/{runId}/analysis",
+            "/runs/{runId}/detections/",
             get_with(get_pipeline_run_analysis, get_pipeline_run_analysis_docs),
         )
         .api_route(
-            "/runs/{runId}/redact/",
+            "/runs/{runId}/redactions/",
             post_with(redact_pipeline_run, redact_pipeline_run_docs),
         )
         .with_path_items(|item| item.tag("Pipeline Runs"))

--- a/crates/nvisy-server/src/middleware/specification.rs
+++ b/crates/nvisy-server/src/middleware/specification.rs
@@ -30,6 +30,7 @@ use aide::scalar::Scalar;
 use aide::transform::TransformOpenApi;
 use axum::routing::{Router, get};
 use axum::{Extension, Json};
+use serde_json::Value;
 
 /// OpenAPI configuration for aide integration.
 ///
@@ -102,10 +103,76 @@ where
             .route(&config.scalar_ui, scalar.axum_route())
             .route(&config.open_api_json, get(serve_openapi));
 
-        // Generate the OpenAPI specification with tags and add it as extension
-        router
-            .finish_api_with(&mut api, api_docs)
-            .layer(Extension(api))
+        let router = router.finish_api_with(&mut api, api_docs);
+        collapse_null_types(&mut api);
+        router.layer(Extension(api))
+    }
+}
+
+/// Removes the `null` variant that schemars adds to optional-field schemas
+/// across every component schema.
+///
+/// schemars encodes `Option<T>` in one of two ways: for primitives as the union
+/// `type: [T, null]`, and for referenced types (enums, structs) as
+/// `anyOf: [T, { type: null }]`. Both rely on absence from `required` to signal
+/// optionality. Optional response fields are omitted when absent rather than
+/// serialized as `null` (each carries `skip_serializing_if = "Option::is_none"`),
+/// so the `null` variant describes a value the API never emits and only widens
+/// generated clients to `T | null`. Dropping it tightens each schema to match
+/// what is actually sent.
+///
+/// This runs after schema generation because aide accumulates the component
+/// schemas into `api.components` only once the router is finished.
+fn collapse_null_types(api: &mut OpenApi) {
+    let Some(components) = api.components.as_mut() else {
+        return;
+    };
+
+    for schema in components.schemas.values_mut() {
+        if let Some(object) = schema.json_schema.as_object_mut() {
+            collapse_in_object(object);
+        }
+    }
+}
+
+/// Recursively removes null variants from optional-field schemas within a value.
+fn collapse_in_value(value: &mut Value) {
+    match value {
+        Value::Object(map) => collapse_in_object(map),
+        Value::Array(items) => items.iter_mut().for_each(collapse_in_value),
+        _ => {}
+    }
+}
+
+/// Removes the `null` variant a schema object gained from an `Option<T>`, in
+/// both the `type: [T, null]` and `anyOf: [T, { type: null }]` forms, then
+/// recurses into nested schemas.
+///
+/// A `type` array that collapses to a single member becomes that member as a
+/// plain string. An `anyOf` whose only remaining branch is a single schema is
+/// hoisted into this object, preserving sibling keywords such as `description`.
+fn collapse_in_object(map: &mut serde_json::Map<String, Value>) {
+    if let Some(Value::Array(types)) = map.get_mut("type") {
+        types.retain(|entry| entry != "null");
+        if let [only] = types.as_slice() {
+            let only = only.clone();
+            map.insert("type".to_owned(), only);
+        }
+    }
+
+    if let Some(Value::Array(variants)) = map.get_mut("anyOf") {
+        variants.retain(|variant| variant.get("type") != Some(&Value::String("null".to_owned())));
+        if let [Value::Object(only)] = variants.as_slice() {
+            let only = only.clone();
+            map.remove("anyOf");
+            for (key, value) in only {
+                map.entry(key).or_insert(value);
+            }
+        }
+    }
+
+    for nested in map.values_mut() {
+        collapse_in_value(nested);
     }
 }
 
@@ -179,4 +246,134 @@ fn api_docs(api: TransformOpenApi) -> TransformOpenApi {
             description: Some("Webhook configuration".into()),
             ..Default::default()
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use aide::openapi::{Components, OpenApi, SchemaObject};
+    use serde_json::json;
+
+    use super::collapse_null_types;
+
+    #[test]
+    fn collapses_null_unions_across_nested_schemas() {
+        let mut api = OpenApi::default();
+        let mut components = Components::default();
+        components.schemas.insert(
+            "Sample".to_owned(),
+            SchemaObject {
+                json_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "required": { "type": "string" },
+                        "optional": { "type": ["string", "null"] },
+                        "enumeration": {
+                            "description": "field description",
+                            "anyOf": [
+                                { "$ref": "#/components/schemas/SortOrder" },
+                                { "type": "null" }
+                            ]
+                        },
+                        "nested": {
+                            "type": "object",
+                            "properties": {
+                                "count": { "type": ["integer", "null"] }
+                            }
+                        }
+                    },
+                    "required": ["required"]
+                })
+                .try_into()
+                .expect("valid schema"),
+                external_docs: None,
+                example: None,
+            },
+        );
+        api.components = Some(components);
+
+        collapse_null_types(&mut api);
+
+        let schema = api.components.as_ref().unwrap().schemas["Sample"]
+            .json_schema
+            .as_value();
+
+        assert_eq!(
+            schema.pointer("/properties/optional/type"),
+            Some(&json!("string")),
+            "optional primitive collapses to a plain string"
+        );
+        assert_eq!(
+            schema.pointer("/properties/enumeration/$ref"),
+            Some(&json!("#/components/schemas/SortOrder")),
+            "optional referenced type hoists the non-null anyOf branch"
+        );
+        assert!(
+            schema.pointer("/properties/enumeration/anyOf").is_none(),
+            "the anyOf wrapper is removed once null is stripped"
+        );
+        assert_eq!(
+            schema.pointer("/properties/enumeration/description"),
+            Some(&json!("field description")),
+            "the field's own description survives hoisting"
+        );
+        assert_eq!(
+            schema.pointer("/properties/nested/properties/count/type"),
+            Some(&json!("integer")),
+            "null is stripped from nested schemas too"
+        );
+        assert_eq!(
+            schema.pointer("/properties/required/type"),
+            Some(&json!("string")),
+            "non-nullable fields are unaffected"
+        );
+    }
+
+    /// Guards the invariant [`collapse_null_types`] relies on: because the spec
+    /// strips `null` from every optional field's type, a response field that
+    /// serialized `null` would make the schema lie. Every `Option<T>` field in
+    /// a response type must therefore either omit itself when `None`
+    /// (`skip_serializing_if`) or never serialize at all (`skip`).
+    #[test]
+    fn response_optionals_never_serialize_null() {
+        let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/src/handler/response");
+
+        let mut offenders = Vec::new();
+        for entry in std::fs::read_dir(dir).expect("response dir is readable") {
+            let path = entry.expect("dir entry").path();
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+
+            let source = std::fs::read_to_string(&path).expect("source is readable");
+            let lines: Vec<&str> = source.lines().collect();
+            for (index, line) in lines.iter().enumerate() {
+                let trimmed = line.trim_start();
+                let is_optional_field = trimmed.starts_with("pub ")
+                    && !trimmed.starts_with("pub fn ")
+                    && trimmed.contains(": Option<")
+                    && !trimmed.contains("//");
+                if !is_optional_field {
+                    continue;
+                }
+
+                let start = index.saturating_sub(4);
+                let context = lines[start..index].join("\n");
+                let skipped = context.contains("skip_serializing_if")
+                    || context.contains("serde(skip)")
+                    || context.contains("serde(skip,")
+                    || context.contains("serde(skip ");
+                if !skipped {
+                    let file = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");
+                    offenders.push(format!("{file}:{}  {}", index + 1, trimmed));
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "response Option<T> fields missing `skip_serializing_if`/`skip` \
+             (they would serialize null, which the OpenAPI schema strips):\n{}",
+            offenders.join("\n")
+        );
+    }
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,6 +57,6 @@ ENV RUST_LOG=info \
 USER nvisy
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD curl -sf http://localhost:8080/health || exit 1
+    CMD curl -sf http://localhost:8080/health/ || exit 1
 
 ENTRYPOINT ["/usr/local/bin/nvisy-server"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -92,7 +92,7 @@ The Dockerfile uses a multi-stage build:
 3. **Runtime:** minimal Debian image with only the binary and runtime libraries
 
 The runtime image runs as a non-root user (`nvisy`, UID 1000) and includes a
-health check endpoint at `/health`.
+health check endpoint at `/health/`.
 
 ## NATS Configuration
 
@@ -138,7 +138,7 @@ All services expose health check endpoints:
 
 | Service    | Endpoint                | Method   |
 | ---------- | ----------------------- | -------- |
-| Server     | `/health`               | HTTP GET |
+| Server     | `/health/`              | HTTP GET |
 | PostgreSQL | `pg_isready`            | CLI      |
 | NATS       | `/healthz` on port 8222 | HTTP GET |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -273,7 +273,7 @@ filtering in production without relying on log levels alone.
 
 ### Health Checks
 
-The server exposes a `/health` endpoint that returns per-component status
+The server exposes a `/health/` endpoint that returns per-component status
 (PostgreSQL, NATS) with overall system health (healthy, degraded, unhealthy).
 Cached health checks serve load balancer probes; authenticated requests
 trigger real-time checks.


### PR DESCRIPTION
## Summary

Two related cleanups to the HTTP surface, driven by TypeScript SDK generation surfacing spurious `| null` types and inconsistent route paths.

### 1. OpenAPI null-stripping (`feat(openapi)`)

The SDK was generating `field?: T | null` for every optional field. Root cause was our own inconsistency plus schemars' faithful-but-verbose encoding of `Option<T>`. Fixed at two layers:

- **Runtime:** every optional response field now carries `#[serde(skip_serializing_if = "Option::is_none")]`, so the API **omits** optional fields when absent instead of sending literal `null`. Optionality is signalled by absence from `required`, per REST norms.
- **Spec:** a post-generation transform collapses the `null` variant schemars adds for `Option<T>` — both the primitive `type: [T, null]` union **and** the referenced-type `anyOf: [T, {type: null}]` form (enums, structs). Clients now generate `field?: T`.

A **guard test** enforces the invariant the transform relies on: every response `Option<T>` must omit-or-skip, so no field can silently serialize a `null` the schema claims it never sends.

Verified on the live spec: **230 schemas, 0 null-type unions, 0 `anyOf` null branches, 0 `nullable:true` noise.**

### 2. Route slash + naming cleanup (`refactor(routes)`)

- **Trailing slashes normalized** — all 39 paths now end in `/` (previously 6 outliers: `/auth/*`, `/files/{id}/content`, `/members/leave`, `/notifications/unread`, `/health`). The Dockerfile healthcheck and docs are updated to `/health/` in lockstep, since axum returns **404, not a redirect**, for the slashless form.
- **Run sub-resources renamed** to plural nouns:
  - `GET /runs/{runId}/analysis` → `/runs/{runId}/detections/`
  - `POST /runs/{runId}/redact/` → `/runs/{runId}/redactions/`

  Scoped to the consumer-facing surface (URL path + OpenAPI summary). aide emits no `operationId`, so SDK method names derive from the path. The internal `AnalyzedDocument` type and `analyzed_document_key` DB column are intentionally left untouched (separate migration-bearing refactor).

## Test plan

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-features` — 65 unit + 13 doctests pass
- `RUSTDOCFLAGS="-D warnings" cargo doc` — clean
- Live spec inspected: all paths slash-terminated, both renames present, zero null variants remaining
- Confirmed `/health/` → serves, `/health` → 404 (slash is enforced, healthcheck updated accordingly)

## Breaking changes

Route paths change — SDK consumers must regenerate against the new spec. Affected callers of `/health` (container healthcheck) are updated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)