### PR TITLE
Advertise supported file formats/modalities in the OpenAPI schema

### DIFF
--- a/crates/nvisy-server/src/handler/request/files.rs
+++ b/crates/nvisy-server/src/handler/request/files.rs
@@ -1,8 +1,13 @@
 //! File request types.
 
+use std::borrow::Cow;
+use std::collections::BTreeSet;
+
+use derive_more::{AsRef, Into};
+use nvisy_engine::FormatRegistry;
 use nvisy_postgres::model::UpdateWorkspaceFile as UpdateFileModel;
 use nvisy_postgres::types::FileFilter;
-use schemars::JsonSchema;
+use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
@@ -33,6 +38,55 @@ impl UpdateFile {
     }
 }
 
+/// Defines a transparent string newtype whose OpenAPI schema enumerates the
+/// values the built-in codec registry supports, so the API advertises exactly
+/// which values are accepted (each is validated again at request time).
+///
+/// The extractor closure maps each registered format to the strings it
+/// contributes; the schema `enum` is their sorted, de-duplicated union.
+macro_rules! registry_token {
+    ($(#[$meta:meta])* $name:ident => $desc:literal, |$format:ident| $values:expr) => {
+        $(#[$meta])*
+        #[must_use]
+        #[derive(Debug, Clone, Serialize, Deserialize, AsRef, Into)]
+        #[serde(transparent)]
+        #[as_ref(str)]
+        pub struct $name(String);
+
+        impl JsonSchema for $name {
+            fn schema_name() -> Cow<'static, str> {
+                stringify!($name).into()
+            }
+
+            fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+                let values: Vec<String> = FormatRegistry::with_builtin()
+                    .iter()
+                    .flat_map(|$format| $values)
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
+                    .collect();
+                schemars::json_schema!({
+                    "type": "string",
+                    "enum": values,
+                    "description": $desc,
+                })
+            }
+        }
+    };
+}
+
+registry_token!(
+    /// A file-extension filter token (`pdf`, `png`).
+    FormatToken => "A supported file extension.",
+    |format| format.extensions().iter().map(|e| e.as_ref().to_owned())
+);
+
+registry_token!(
+    /// A modality filter token (`text`, `tabular`, `image`, `audio`).
+    ModalityToken => "A supported document modality.",
+    |format| std::iter::once(format.modality().to_owned())
+);
+
 /// Query parameters for listing files.
 #[must_use]
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -41,13 +95,13 @@ pub struct ListFiles {
     /// Search by file name (case-insensitive, partial match).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub search: Option<String>,
-    /// Filter by file extension (`pdf`, `png`). Each entry expands to its
-    /// format's full extension set (so `jpg` also matches `jpeg`).
+    /// Filter by file extension. Each entry expands to its format's full
+    /// extension set (so `jpg` also matches `jpeg`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub formats: Option<Vec<String>>,
+    pub formats: Option<Vec<FormatToken>>,
     /// Filter by modality (`text`, `tabular`, `image`, `audio`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub modality: Option<Vec<String>>,
+    pub modality: Option<Vec<ModalityToken>>,
 }
 
 impl ListFiles {
@@ -59,26 +113,19 @@ impl ListFiles {
     /// intersection). A facet that is absent imposes no constraint. Returns
     /// [`UnknownFormatToken`] if a token matches no known extension or modality.
     pub fn to_filter(&self, engine: &EngineService) -> Result<FileFilter, UnknownFormatToken> {
+        let formats = self.formats.as_deref();
+        let formats = formats.map(|t| engine.resolve_extensions(t)).transpose()?;
+
+        let modality = self.modality.as_deref();
+        let modality = modality.map(|t| engine.resolve_modalities(t)).transpose()?;
+
         let mut filter = FileFilter::new();
-        if let Some(search) = self.search.clone().filter(|s| !s.is_empty()) {
-            filter = filter.with_search(search);
+        if let Some(search) = self.search.as_deref().filter(|s| !s.is_empty()) {
+            filter = filter.with_search(search.to_owned());
         }
-
-        let formats = self
-            .formats
-            .as_ref()
-            .map(|t| engine.resolve_extensions(t))
-            .transpose()?;
-        let modality = self
-            .modality
-            .as_ref()
-            .map(|t| engine.resolve_modalities(t))
-            .transpose()?;
-
         if let Some(extensions) = intersect_facets(formats, modality) {
             filter = filter.with_extensions(extensions);
         }
-
         Ok(filter)
     }
 }
@@ -96,5 +143,32 @@ fn intersect_facets(
         }
         (Some(only), None) | (None, Some(only)) => Some(only),
         (None, None) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The filter schemas must advertise the registry's supported values as an
+    /// OpenAPI `enum`, so the API contract stays in sync with what the
+    /// deployment actually accepts.
+    #[test]
+    fn filter_schemas_enumerate_supported_values() {
+        let mut generator = SchemaGenerator::default();
+
+        let formats = FormatToken::json_schema(&mut generator);
+        let formats = formats.as_value()["enum"]
+            .as_array()
+            .expect("format schema has an enum");
+        assert!(formats.iter().any(|v| v == "png"));
+        assert!(formats.iter().any(|v| v == "txt"));
+
+        let modalities = ModalityToken::json_schema(&mut generator);
+        let modalities = modalities.as_value()["enum"]
+            .as_array()
+            .expect("modality schema has an enum");
+        assert!(modalities.iter().any(|v| v == "text"));
+        assert!(modalities.iter().any(|v| v == "image"));
     }
 }


### PR DESCRIPTION
## Summary

When the `FileFormat` enum was removed (#164), the file list filter's `?formats=` and `?modality=` params became plain `array<string>` — the OpenAPI spec no longer told clients which values are accepted (validity was only enforced at runtime via a 400). This restores that contract.

## Change

- `?formats=` → `FormatToken`, `?modality=` → `ModalityToken`: transparent string newtypes whose `JsonSchema` emits an `enum` of the supported values.
- The enum is derived **at schema-generation time** from `FormatRegistry::with_builtin()` — the same authority the engine validates against — so the spec can't drift from what's actually accepted, and it correctly reflects feature-gated builds (e.g. no phantom `pdf`/`mp3` when those codecs aren't compiled in).
- A `registry_token!` macro generates both newtypes from a per-format value extractor (no duplicated boilerplate); a test asserts the schemas enumerate the registry's values.

No behavior change to filtering — the values still resolve through `EngineService::resolve_extensions` / `resolve_modalities` and validate the same way; this only makes the accepted set discoverable in the schema again.

## Verification

- `cargo clippy --all-targets --all-features --workspace -- -D warnings` ✅
- `cargo +nightly fmt --all -- --check` ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` ✅
- `cargo test --all-features -p nvisy-server` ✅ (incl. the schema-enum test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)