### PR TITLE
Use consistent HTTP methods for updates and invite replies

### DIFF
--- a/crates/nvisy-server/src/handler/connections.rs
+++ b/crates/nvisy-server/src/handler/connections.rs
@@ -384,7 +384,7 @@ pub fn routes() -> ApiRouter<ServiceState> {
         .api_route(
             "/workspaces/{workspaceSlug}/connections/{connectionId}/",
             get_with(read_connection, read_connection_docs)
-                .put_with(update_connection, update_connection_docs)
+                .patch_with(update_connection, update_connection_docs)
                 .delete_with(delete_connection, delete_connection_docs),
         )
         .with_path_items(|item| item.tag("Connections"))

--- a/crates/nvisy-server/src/handler/invites.rs
+++ b/crates/nvisy-server/src/handler/invites.rs
@@ -317,7 +317,7 @@ async fn reply_to_invite(
     WorkspaceContext(workspace): WorkspaceContext,
     Path(path_params): Path<InvitePathParams>,
     Json(request): Json<ReplyInvite>,
-) -> Result<(StatusCode, Json<Invite>)> {
+) -> Result<(StatusCode, Json<Option<Member>>)> {
     tracing::info!(target: TRACING_TARGET, "Responding to workspace invitation");
 
     let mut conn = pg_client.get_connection().await?;
@@ -331,7 +331,7 @@ async fn reply_to_invite(
             .with_resource("workspace_invite"));
     }
 
-    let workspace_invite = if request.accept_invite {
+    if request.accept_invite {
         // Check if user is already a member
         if conn
             .find_workspace_member(invite.workspace_id, auth_state.account_id)
@@ -348,41 +348,48 @@ async fn reply_to_invite(
         let invited_role = invite.invited_role;
         let account_id = auth_state.account_id;
 
-        let accepted = conn
+        let (workspace_member, account) = conn
             .transaction(async |conn| {
-                let accepted = conn.accept_workspace_invite(invite_id, account_id).await?;
+                conn.accept_workspace_invite(invite_id, account_id).await?;
 
                 let new_member = NewWorkspaceMember::new(workspace_id, account_id, invited_role);
                 conn.add_workspace_member(new_member).await?;
 
-                Ok::<_, PgError>(accepted)
+                let result = conn
+                    .find_workspace_member_with_account(workspace_id, account_id)
+                    .await?
+                    .ok_or_else(|| PgError::Unexpected("Member not found after insert".into()))?;
+
+                Ok::<_, PgError>(result)
             })
             .await?;
 
         tracing::info!(target: TRACING_TARGET, "Invitation accepted");
-        accepted
+        Ok((
+            StatusCode::CREATED,
+            Json(Some(Member::from_model(workspace_member, account))),
+        ))
     } else {
-        let declined = conn
-            .reject_workspace_invite(path_params.invite_id, auth_state.account_id)
+        conn.reject_workspace_invite(path_params.invite_id, auth_state.account_id)
             .await?;
 
         tracing::info!(target: TRACING_TARGET, "Invitation declined");
-        declined
-    };
-
-    Ok((
-        StatusCode::OK,
-        Json(Invite::from_model(workspace_invite, workspace.slug)),
-    ))
+        Ok((StatusCode::OK, Json(None)))
+    }
 }
 
 fn reply_to_invite_docs(op: TransformOperation) -> TransformOperation {
     op.summary("Reply to invitation")
-        .description("Allows the invitee to accept or decline a workspace invitation.")
-        .response::<200, Json<Invite>>()
+        .description(
+            "Accepts or declines a workspace invitation. On accept the user becomes a \
+             member and the new membership is returned; on decline no membership is created.",
+        )
+        .response::<200, Json<Option<Member>>>()
+        .response::<201, Json<Member>>()
         .response::<400, Json<ErrorResponse>>()
         .response::<401, Json<ErrorResponse>>()
         .response::<404, Json<ErrorResponse>>()
+        .response::<409, Json<ErrorResponse>>()
 }
 
 /// Generates a shareable invite code for a workspace.

--- a/crates/nvisy-server/src/handler/policies.rs
+++ b/crates/nvisy-server/src/handler/policies.rs
@@ -340,7 +340,7 @@ pub fn routes() -> ApiRouter<ServiceState> {
         .api_route(
             "/workspaces/{workspaceSlug}/policies/{policySlug}/",
             get_with(read_policy, read_policy_docs)
-                .put_with(update_policy, update_policy_docs)
+                .patch_with(update_policy, update_policy_docs)
                 .delete_with(delete_policy, delete_policy_docs),
         )
         .with_path_items(|item| item.tag("Policies"))

--- a/crates/nvisy-server/src/handler/webhooks.rs
+++ b/crates/nvisy-server/src/handler/webhooks.rs
@@ -399,7 +399,7 @@ pub fn routes() -> ApiRouter<ServiceState> {
         .api_route(
             "/workspaces/{workspaceSlug}/webhooks/{webhookId}/",
             get_with(read_webhook, read_webhook_docs)
-                .put_with(update_webhook, update_webhook_docs)
+                .patch_with(update_webhook, update_webhook_docs)
                 .delete_with(delete_webhook, delete_webhook_docs),
         )
         .api_route(


### PR DESCRIPTION
## Summary

An audit of HTTP methods across the handlers found two inconsistencies; this fixes both.

### 1. Update endpoints: PUT → PATCH
Connection, policy, and webhook updates were registered as **PUT**, but their request DTOs are entirely `Option` fields and the handlers do partial merges (`..Default::default()`, omitted field = unchanged) — i.e. **PATCH semantics** mislabeled as PUT. The other seven update endpoints (account, member, file, pipeline, workspace, notification settings, api token) already use PATCH. Switched these three so all ten agree.

### 2. Invite replies: consistent status + body
The two invite-reply endpoints diverged even though both accept-paths create a membership:
- `reply_to_invite` (by id): returned `200 + Invite`
- `reply_to_invite_code` (by code): returned `201 + Member`

Aligned `reply_to_invite` with `reply_to_invite_code`: **`201 + Member` on accept**, **`200 + None` on decline**. The same action now reports the same result regardless of which path a client uses, and the accept path no longer hides the created membership behind a `200 + Invite`.

## Notes

Reviewed but deliberately left unchanged (defensible, not bugs): `POST /members/leave/` (a distinct self-service action, DELETE is reserved for admin-remove which forbids self-removal), and the action POSTs (test webhook, redact run, generate code, detect run).

Breaking for clients calling the old `PUT` update routes or relying on the old invite-reply shape — acceptable pre-release.

## Verification

- `cargo clippy --all-targets --all-features --workspace -- -D warnings` ✅
- `cargo +nightly fmt --all -- --check` ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` ✅
- `cargo test --all-features -p nvisy-server` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)