### PR TITLE
Attribute HTTP errors to a route in logs

### DIFF
--- a/crates/nvisy-server/src/handler/mod.rs
+++ b/crates/nvisy-server/src/handler/mod.rs
@@ -25,6 +25,7 @@ mod workspaces;
 use std::collections::HashSet;
 
 use aide::axum::ApiRouter;
+use axum::http::{Method, Uri};
 use axum::middleware::from_fn_with_state;
 use axum::response::{IntoResponse, Response};
 pub use error::{Error, ErrorKind, Result};
@@ -34,9 +35,25 @@ pub use utility::{BuiltinModule, CustomRoutes, RouterMapFn};
 use crate::middleware::{require_authentication, validate_token_middleware};
 use crate::service::ServiceState;
 
-#[inline]
-async fn handler() -> Response {
-    ErrorKind::NotFound.into_response()
+/// Tracing target for unmatched-route fallbacks.
+const TRACING_TARGET_FALLBACK: &str = "nvisy_server::handler::fallback";
+
+/// Fallback for requests that match no route.
+///
+/// Logs the method and path so unmatched requests are diagnosable, and echoes
+/// the path in the response context.
+async fn handler(method: Method, uri: Uri) -> Response {
+    tracing::warn!(
+        target: TRACING_TARGET_FALLBACK,
+        %method,
+        path = %uri.path(),
+        "No route matched request"
+    );
+
+    ErrorKind::NotFound
+        .with_resource("route")
+        .with_context(format!("No route matches {method} {}", uri.path()))
+        .into_response()
 }
 
 /// Returns an [`ApiRouter`] with all private routes, minus any excluded module.

--- a/crates/nvisy-server/src/middleware/observability.rs
+++ b/crates/nvisy-server/src/middleware/observability.rs
@@ -21,6 +21,22 @@ use super::RouteCategory;
 /// Tracing target for request metrics.
 const TRACING_TARGET_METRICS: &str = "nvisy_server::metrics";
 
+/// Tracing target for the per-request span.
+const TRACING_TARGET_REQUEST: &str = "nvisy_server::request";
+
+/// Builds the per-request tracing span carrying the method and path.
+///
+/// Every event logged while handling the request inherits these fields, so
+/// error responses (4xx/5xx) are always attributable to a route.
+fn request_span(request: &Request) -> tracing::Span {
+    tracing::info_span!(
+        target: TRACING_TARGET_REQUEST,
+        "request",
+        method = %request.method(),
+        path = %request.uri().path(),
+    )
+}
+
 /// Extension trait for `axum::`[`Router`] to apply observability middleware.
 ///
 /// This trait provides convenient methods to add observability features
@@ -52,7 +68,7 @@ where
             header::AUTHORIZATION,
             header::COOKIE,
         ]))
-        .layer(TraceLayer::new_for_http())
+        .layer(TraceLayer::new_for_http().make_span_with(request_span))
         .layer(SetRequestIdLayer::new(
             header::HeaderName::from_static("x-request-id"),
             MakeRequestUuid,


### PR DESCRIPTION
## Problem

A 404 seen while testing the website logged with no way to tell which request caused it:

```
WARN nvisy_server::handler::response::errors: HTTP error response status=404 Not Found name=not_found Resource not found resource=None context=None
```

No route, no method, no resource. Two gaps: the error-response log had no request context, and the unmatched-route fallback returned a bare `NotFound`.

## Changes

- **Per-request span** (`observability.rs`): the `TraceLayer` now opens an info-level `request` span carrying `method` and `path` via `make_span_with`. Every event logged while handling the request — including the error-response warning — nests under it, so **any** 4xx/5xx is attributable to a route:

  ```
  WARN request{method=GET path=/api/v1/foo}: ...errors: HTTP error response status=404 ...
  ```

- **Fallback** (`handler/mod.rs`): the unmatched-route handler now logs `method` + `path` under `nvisy_server::handler::fallback` and returns `resource="route"` with a context naming the missed path, instead of a bare `NotFound`. The three 404s in the report came from here (frontend hitting an unregistered path).

## Verification

`cargo check` / `clippy -D warnings` / nightly `fmt --check` / `doc -D warnings` / `test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)