### PR TITLE
Update runtime (nvisy-engine) to d694a32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1675,7 +1675,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#2d31e87887c9422c2ed2a77914c749fc6fe497f9"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -1695,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "elide-bento"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#1b9c933ba1d439931b14d69c3478a0d757ddda87"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d694a32b2b15101d055aa0e4041e3b57cd1df6de"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -1711,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#2d31e87887c9422c2ed2a77914c749fc6fe497f9"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#2d31e87887c9422c2ed2a77914c749fc6fe497f9"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#2d31e87887c9422c2ed2a77914c749fc6fe497f9"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#2d31e87887c9422c2ed2a77914c749fc6fe497f9"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#2d31e87887c9422c2ed2a77914c749fc6fe497f9"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#2d31e87887c9422c2ed2a77914c749fc6fe497f9"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1799,6 +1799,7 @@ dependencies = [
  "rig",
  "schemars",
  "serde",
+ "serde_json",
  "thiserror",
  "tracing",
  "unicode-normalization",
@@ -1807,7 +1808,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#2d31e87887c9422c2ed2a77914c749fc6fe497f9"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1821,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#2d31e87887c9422c2ed2a77914c749fc6fe497f9"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1831,7 +1832,7 @@ dependencies = [
 [[package]]
 name = "elide-orchestration"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#2d31e87887c9422c2ed2a77914c749fc6fe497f9"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -1845,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#2d31e87887c9422c2ed2a77914c749fc6fe497f9"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -1865,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#2d31e87887c9422c2ed2a77914c749fc6fe497f9"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1880,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#2d31e87887c9422c2ed2a77914c749fc6fe497f9"
+source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -2893,15 +2894,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3685,7 +3677,7 @@ dependencies = [
 [[package]]
 name = "nvisy-engine"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#1b9c933ba1d439931b14d69c3478a0d757ddda87"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d694a32b2b15101d055aa0e4041e3b57cd1df6de"
 dependencies = [
  "bytes",
  "derive_builder",
@@ -3740,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "nvisy-policy"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#1b9c933ba1d439931b14d69c3478a0d757ddda87"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d694a32b2b15101d055aa0e4041e3b57cd1df6de"
 dependencies = [
  "derive_more",
  "elide-core",
@@ -3785,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "nvisy-schema"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#1b9c933ba1d439931b14d69c3478a0d757ddda87"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d694a32b2b15101d055aa0e4041e3b57cd1df6de"
 dependencies = [
  "bytes",
  "elide-core",
@@ -4869,18 +4861,42 @@ checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "rig"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aac59326725633a25c21ef2c24d33c4d00dc38a1f0cc097205a7a9bde70b482"
+checksum = "2ce03971e6115d30ef53fb3244d06718a4e62bbde82c103065600c09459b989a"
 dependencies = [
+ "rig-agent",
  "rig-core",
+ "rig-derive",
+]
+
+[[package]]
+name = "rig-agent"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b0796bbf47d7b76670401aac975bc619cf7fba3482b22dfe14992edaa9c2e04"
+dependencies = [
+ "async-stream",
+ "fastrand",
+ "futures",
+ "http",
+ "indexmap",
+ "rig-core",
+ "rig-derive",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
 name = "rig-core"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8731dd5532b3a12ce1613af73073fb2051ef750f50c504778c21d55ae933cac"
+checksum = "35f5520515ae8f6851adcbc6fde9eea8e96f657418c062e16c82cd81cce44e8e"
 dependencies = [
  "as-any",
  "async-stream",
@@ -4913,16 +4929,14 @@ dependencies = [
 
 [[package]]
 name = "rig-derive"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e98dde7a4e59e083e7396126ee4c83498c5bff605d126654e67815fa230a78"
+checksum = "eb868fcebdf3ba425e3afad2e4926bb6d9e1188a856843b00bcee2e15c07424f"
 dependencies = [
  "convert_case 0.11.0",
- "indoc",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "serde_json",
  "syn 2.0.117",
 ]
 

--- a/crates/nvisy-server/src/handler/request/pipelines.rs
+++ b/crates/nvisy-server/src/handler/request/pipelines.rs
@@ -4,10 +4,10 @@
 //! creation, updates, and filtering. All request types support JSON serialization
 //! and validation.
 
-use nvisy_engine::entity::ConfidenceThreshold;
 use nvisy_engine::plan::{
     LabelCatalogParams, MergingStrategyParams, RecognizerParams, ScopeParams, TiebreakerParams,
 };
+use nvisy_engine::primitive::ConfidenceThreshold;
 use nvisy_postgres::model::{NewWorkspacePipeline, UpdateWorkspacePipeline as UpdatePipelineModel};
 use nvisy_postgres::types::{Handle, PipelineStatus};
 use schemars::JsonSchema;

--- a/crates/nvisy-server/src/service/engine/config.rs
+++ b/crates/nvisy-server/src/service/engine/config.rs
@@ -9,8 +9,8 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use nvisy_engine::entity::ConfidenceThreshold;
 use nvisy_engine::plan::{EnricherParams, MergingStrategyParams, TiebreakerParams};
+use nvisy_engine::primitive::ConfidenceThreshold;
 use nvisy_engine::provider::{LlmConfig, LlmRecognizer, NerConfig, NerRecognizer};
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Bumps the `nvisy-engine` / `nvisy-policy` / `nvisy-schema` runtime dependency (github.com/nvisycom/runtime) from `1b9c933` to the latest `main` (`d694a32`), along with the transitive updates it requires (`rig` 0.40→0.41, new `rig-agent`, `elide-stt`).

## Breaking change handled
`ConfidenceThreshold` moved from `nvisy_engine::entity` to `nvisy_engine::primitive` (re-exported from the schema's primitive module). Updated the two import sites:
- `crates/nvisy-server/src/handler/request/pipelines.rs`
- `crates/nvisy-server/src/service/engine/config.rs`

No other API changes — the type is used identically.

## Verification
- All three runtime-repo crates pinned consistently at `d694a32`.
- The committed `docker/engine.example.toml` still parses against the new schema (`example_config_parses` test passes).
- Full gate green: check, clippy `-D warnings`, fmt, machete, doc `-D warnings`, full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)