### PR TITLE
Fix invalid NATS KV key in scheduler leader lock

### DIFF
--- a/crates/nvisy-server/src/service/object/worker.rs
+++ b/crates/nvisy-server/src/service/object/worker.rs
@@ -148,9 +148,10 @@ impl ConnectionSyncWorker {
 
         // Leader election for this wall-clock period: the lock key is the period
         // itself, so exactly one instance wins per period regardless of each
-        // instance's tick phase. The bucket TTL reclaims old period keys.
+        // instance's tick phase. The bucket TTL reclaims old period keys. Segments
+        // are joined with `.`, which NATS KV keys allow (`[-/_=.a-zA-Z0-9]`).
         let period = now.as_second() / TICK_INTERVAL.as_secs() as i64;
-        let lock_key = LockKey::from(format!("{SCHEDULER_LOCK_KEY}:{period}").as_str());
+        let lock_key = LockKey::from(format!("{SCHEDULER_LOCK_KEY}.{period}").as_str());
         let locks = self
             .nats
             .kv_store::<LockKey, u64, SchedulerLocksBucket>()


### PR DESCRIPTION
## Symptom
Running the server logs `Scheduler tick failed ... Operation 'kv_create' failed` on every scheduler tick:

```
ERROR nvisy_server::worker::connection_sync: Scheduler tick failed error=... Operation 'kv_create' failed
```

## Root cause
The connection-sync scheduler built its per-period leader-election key as `connection-sync-scheduler:{period}`. NATS KV keys allow only `[-/_=.a-zA-Z0-9]` (per async-nats `VALID_KEY_RE`), so the `:` separator made every `store.create` fail with `InvalidKey`.

This was latent: before the recent review fix, `KvStore::create` mapped **all** errors to `Ok(false)`, so the failure masqueraded as "another instance owns this period" — the scheduler logged nothing and **scheduled syncs silently never fired**. Propagating the real error (that fix) surfaced it.

## Fix
Join the key segments with `.` (a valid KV key char) instead of `:`.

## Verification
Ran the server against live NATS for two tick intervals: **zero** `Scheduler tick failed` errors; the tick now performs the KV compare-and-set correctly (first tick acquires the period lock, subsequent ticks in the same TTL window correctly report the lock already held). clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)