### PR TITLE
Typed provider config for connections

### DIFF
--- a/crates/nvisy-object/src/providers/azure.rs
+++ b/crates/nvisy-object/src/providers/azure.rs
@@ -6,7 +6,7 @@ use derive_more::Deref;
 use object_store::azure::MicrosoftAzureBuilder;
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::{Client, redact};
 use crate::client::ObjectStoreClient;
@@ -14,9 +14,10 @@ use crate::error::Error;
 
 /// Typed credentials for Azure Blob Storage.
 ///
-/// Secret fields are masked in the [`Debug`] output; the struct is
-/// deserialize-only and never serialized back out.
-#[derive(Deserialize)]
+/// Secret fields are masked in the [`Debug`] output. Serialization exists only
+/// to persist the credentials encrypted at rest; they are never returned in API
+/// responses.
+#[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct AzureCredentials {

--- a/crates/nvisy-object/src/providers/gcs.rs
+++ b/crates/nvisy-object/src/providers/gcs.rs
@@ -6,7 +6,7 @@ use derive_more::Deref;
 use object_store::gcp::GoogleCloudStorageBuilder;
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::{Client, redact};
 use crate::client::ObjectStoreClient;
@@ -14,9 +14,10 @@ use crate::error::Error;
 
 /// Typed credentials for Google Cloud Storage.
 ///
-/// Secret fields are masked in the [`Debug`] output; the struct is
-/// deserialize-only and never serialized back out.
-#[derive(Deserialize)]
+/// Secret fields are masked in the [`Debug`] output. Serialization exists only
+/// to persist the credentials encrypted at rest; they are never returned in API
+/// responses.
+#[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GcsCredentials {

--- a/crates/nvisy-object/src/providers/mod.rs
+++ b/crates/nvisy-object/src/providers/mod.rs
@@ -10,28 +10,78 @@ pub use azure::{AzureCredentials, AzureProvider};
 pub use gcs::{GcsCredentials, GcsProvider};
 use object_store::prefix::PrefixStore;
 pub use s3::{S3Credentials, S3Provider};
-use serde::Deserialize;
-use serde::de::DeserializeOwned;
+#[cfg(feature = "schema")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::client::ObjectStoreClient;
 use crate::error::Error;
 
-/// Cross-provider connection config: an optional root prefix shared by every
-/// provider, plus the provider-specific credentials flattened alongside it.
+/// A fully-typed object-store connection configuration.
 ///
-/// The credential JSON is flat — e.g. `{ "bucket": "b", "rootPath": "in/",
-/// "accessKeyId": "..." }` — with `rootPath` peeled off here and the rest
-/// deserialized into `C`.
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ProviderConfig<C> {
-    /// Optional root prefix within the bucket/container; keys resolve relative
-    /// to it.
-    #[serde(default)]
-    root_path: Option<String>,
-    /// Provider-specific credentials.
-    #[serde(flatten)]
-    credentials: C,
+/// The `provider` tag selects the variant and thereby the credential shape, so
+/// an S3 connection cannot carry Azure credentials. Each variant carries a
+/// shared optional `root_path` and a nested `credentials` object, giving a wire
+/// shape like
+/// `{ "provider": "s3", "rootPath": "in/", "credentials": { "bucket": "b", "accessKeyId": "..." } }`.
+///
+/// Secrets are masked in [`Debug`]; serialization exists only to persist the
+/// config encrypted at rest, never to return it in API responses.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(
+    tag = "provider",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum ConnectionConfig {
+    /// S3-compatible provider (AWS S3, MinIO, and so on).
+    S3 {
+        /// Optional root prefix within the bucket; keys resolve relative to it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        root_path: Option<String>,
+        /// S3 credentials.
+        credentials: S3Credentials,
+    },
+    /// Azure Blob Storage provider.
+    Azure {
+        /// Optional root prefix within the container; keys resolve relative to it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        root_path: Option<String>,
+        /// Azure credentials.
+        credentials: AzureCredentials,
+    },
+    /// Google Cloud Storage provider.
+    Gcs {
+        /// Optional root prefix within the bucket; keys resolve relative to it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        root_path: Option<String>,
+        /// GCS credentials.
+        credentials: GcsCredentials,
+    },
+}
+
+impl ConnectionConfig {
+    /// The provider identifier for this config (`s3`, `azure`, `gcs`), used for
+    /// the stored `provider` column and for filtering.
+    #[must_use]
+    pub fn provider_id(&self) -> &'static str {
+        match self {
+            Self::S3 { .. } => S3Provider::ID,
+            Self::Azure { .. } => AzureProvider::ID,
+            Self::Gcs { .. } => GcsProvider::ID,
+        }
+    }
+
+    /// The configured root prefix, if any.
+    #[must_use]
+    pub fn root_path(&self) -> Option<&str> {
+        match self {
+            Self::S3 { root_path, .. }
+            | Self::Azure { root_path, .. }
+            | Self::Gcs { root_path, .. } => root_path.as_deref(),
+        }
+    }
 }
 
 /// Scopes a client's keys under `root_path` when one is set, so callers address
@@ -50,7 +100,7 @@ fn with_root_path(client: ObjectStoreClient, root_path: Option<&str>) -> ObjectS
 /// provider (e.g. S3, Azure, GCS).
 pub trait Client: Deref<Target = ObjectStoreClient> + Send + Sync + 'static {
     /// Strongly-typed credentials for this provider.
-    type Credentials: DeserializeOwned + Send;
+    type Credentials: Send;
 
     /// Unique identifier (e.g. `s3`, `azure`).
     const ID: &str;
@@ -61,43 +111,29 @@ pub trait Client: Deref<Target = ObjectStoreClient> + Send + Sync + 'static {
         Self: Sized;
 }
 
-/// Connects to an object store by runtime provider id, returning the shared
-/// [`ObjectStoreClient`] regardless of which provider backs it.
+/// Connects to an object store from a typed [`ConnectionConfig`], returning the
+/// shared [`ObjectStoreClient`] regardless of which provider backs it.
 ///
-/// `raw_credentials` is the provider-specific credential JSON (the shape of
-/// [`S3Credentials`], [`AzureCredentials`], or [`GcsCredentials`]). This is the
-/// entry point for callers that pick a provider at runtime from stored config
-/// rather than at compile time.
-///
-/// Returns an [`Error`] if `provider_id` is unknown or the credentials do not
-/// match the provider's expected shape.
-pub async fn connect(
-    provider_id: &str,
-    raw_credentials: serde_json::Value,
-) -> Result<ObjectStoreClient, Error> {
-    match provider_id {
-        S3Provider::ID => connect_with::<S3Provider>(raw_credentials).await,
-        AzureProvider::ID => connect_with::<AzureProvider>(raw_credentials).await,
-        GcsProvider::ID => connect_with::<GcsProvider>(raw_credentials).await,
-        other => Err(Error::connection(
-            format!("unknown object store provider: {other}"),
-            "object-store",
-        )),
-    }
+/// The config's variant selects the provider, so there is no runtime provider
+/// string to validate; the client is scoped under the config's root path.
+pub async fn connect(config: &ConnectionConfig) -> Result<ObjectStoreClient, Error> {
+    let client = match config {
+        ConnectionConfig::S3 { credentials, .. } => connect_client::<S3Provider>(credentials).await,
+        ConnectionConfig::Azure { credentials, .. } => {
+            connect_client::<AzureProvider>(credentials).await
+        }
+        ConnectionConfig::Gcs { credentials, .. } => {
+            connect_client::<GcsProvider>(credentials).await
+        }
+    }?;
+    Ok(with_root_path(client, config.root_path()))
 }
 
-/// Deserializes `raw_credentials` into `ProviderConfig<C::Credentials>`,
-/// connects, and scopes the client under the config's root path.
-async fn connect_with<C: Client>(
-    raw_credentials: serde_json::Value,
+/// Connects a specific provider and unwraps it to the shared client type.
+async fn connect_client<C: Client>(
+    credentials: &C::Credentials,
 ) -> Result<ObjectStoreClient, Error> {
-    let config: ProviderConfig<C::Credentials> = serde_json::from_value(raw_credentials)
-        .map_err(|e| Error::connection(e.to_string(), C::ID))?;
-    let provider = C::connect(&config.credentials).await?;
-    Ok(with_root_path(
-        (*provider).clone(),
-        config.root_path.as_deref(),
-    ))
+    Ok((*C::connect(credentials).await?).clone())
 }
 
 /// Renders a secret field for [`Debug`]: `<set>` when present, `<unset>` when
@@ -113,41 +149,56 @@ fn redact(value: Option<&str>) -> &'static str {
 mod tests {
     use serde_json::json;
 
-    use super::connect;
-    use crate::error::ErrorKind;
+    use super::{ConnectionConfig, connect};
 
     #[tokio::test]
-    async fn connect_unknown_provider_errors() {
-        let err = connect("nope", json!({})).await.unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::Connection);
-        assert!(err.to_string().contains("unknown object store provider"));
+    async fn deserializes_provider_tagged_config() {
+        let config: ConnectionConfig = serde_json::from_value(json!({
+            "provider": "s3",
+            "credentials": { "bucket": "test-bucket", "region": "us-east-1" },
+        }))
+        .unwrap();
+        assert_eq!(config.provider_id(), "s3");
+        assert!(matches!(config, ConnectionConfig::S3 { .. }));
     }
 
     #[tokio::test]
-    async fn connect_s3_builds_from_credentials() {
+    async fn rejects_unknown_provider_tag() {
+        let result: Result<ConnectionConfig, _> =
+            serde_json::from_value(json!({ "provider": "nope", "credentials": { "bucket": "b" } }));
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_required_field_for_provider() {
+        // S3 without the required `bucket` field.
+        let result: Result<ConnectionConfig, _> = serde_json::from_value(
+            json!({ "provider": "s3", "credentials": { "region": "us-east-1" } }),
+        );
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn connect_s3_builds_from_typed_config() {
         // `build()` is lazy (no network), so valid config yields a client.
-        let creds = json!({ "bucket": "test-bucket", "region": "us-east-1" });
-        assert!(connect("s3", creds).await.is_ok());
+        let config = ConnectionConfig::S3 {
+            root_path: None,
+            credentials: serde_json::from_value(
+                json!({ "bucket": "test-bucket", "region": "us-east-1" }),
+            )
+            .unwrap(),
+        };
+        assert!(connect(&config).await.is_ok());
     }
 
     #[tokio::test]
-    async fn connect_rejects_malformed_credentials() {
-        // Missing the required `bucket` field.
-        let err = connect("s3", json!({ "region": "us-east-1" }))
-            .await
-            .unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::Connection);
-    }
-
-    #[tokio::test]
-    async fn connect_accepts_flattened_root_path() {
-        // `rootPath` sits flat alongside provider credentials and must not
-        // interfere with deserializing the provider-specific fields.
-        let creds = json!({
-            "bucket": "test-bucket",
-            "region": "us-east-1",
+    async fn parses_root_path() {
+        let config: ConnectionConfig = serde_json::from_value(json!({
+            "provider": "s3",
             "rootPath": "incoming/documents",
-        });
-        assert!(connect("s3", creds).await.is_ok());
+            "credentials": { "bucket": "test-bucket", "region": "us-east-1" },
+        }))
+        .unwrap();
+        assert_eq!(config.root_path(), Some("incoming/documents"));
     }
 }

--- a/crates/nvisy-object/src/providers/s3.rs
+++ b/crates/nvisy-object/src/providers/s3.rs
@@ -8,7 +8,7 @@ use derive_more::Deref;
 use object_store::aws::AmazonS3Builder;
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::{Client, redact};
 use crate::client::ObjectStoreClient;
@@ -16,9 +16,10 @@ use crate::error::Error;
 
 /// Typed credentials for S3-compatible provider.
 ///
-/// Secret fields are masked in the [`Debug`] output; the struct is
-/// deserialize-only and never serialized back out.
-#[derive(Deserialize)]
+/// Secret fields are masked in the [`Debug`] output. Serialization exists only
+/// to persist the credentials encrypted at rest; they are never returned in API
+/// responses.
+#[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct S3Credentials {

--- a/crates/nvisy-server/src/extract/auth/permission.rs
+++ b/crates/nvisy-server/src/extract/auth/permission.rs
@@ -62,6 +62,8 @@ pub enum Permission {
     ViewConnections,
     /// Can create, modify, and manage workspace connections.
     ManageConnections,
+    /// Can trigger and cancel connection syncs.
+    RunConnectionSyncs,
 
     // Policy permissions
     /// Can view workspace policies.
@@ -113,7 +115,8 @@ impl Permission {
             | Self::CreatePipelines
             | Self::UpdatePipelines
             | Self::DeletePipelines
-            | Self::RunPipelines => WorkspaceRole::Member,
+            | Self::RunPipelines
+            | Self::RunConnectionSyncs => WorkspaceRole::Member,
 
             // Admin-level permissions (manage workspace resources)
             Self::UpdateWorkspace

--- a/crates/nvisy-server/src/handler/connection_syncs.rs
+++ b/crates/nvisy-server/src/handler/connection_syncs.rs
@@ -11,6 +11,7 @@ use aide::axum::ApiRouter;
 use aide::transform::TransformOperation;
 use axum::extract::State;
 use axum::http::StatusCode;
+use nvisy_object::providers::ConnectionConfig;
 use nvisy_postgres::model::{NewWorkspaceConnectionRun, WorkspaceConnection};
 use nvisy_postgres::query::{
     WorkspaceConnectionRepository, WorkspaceConnectionRunRepository, WorkspaceFileRepository,
@@ -34,10 +35,10 @@ const TRACING_TARGET: &str = "nvisy_server::handler::connection_syncs";
 
 /// Triggers a sync between the connection and the workspace file store.
 ///
-/// Decrypts the stored credentials, opens a `Manual` sync run, and performs the
-/// import or export in the background. Returns `202 Accepted` with the created
-/// sync immediately; poll the sync detail endpoint for completion. Requires
-/// `ManageConnections` permission.
+/// Decrypts the stored connection config, opens a `Manual` sync run, and
+/// performs the import or export in the background. Returns `202 Accepted` with
+/// the created sync immediately; poll the sync detail endpoint for completion.
+/// Requires `RunConnectionSyncs` permission.
 #[tracing::instrument(
     skip_all,
     fields(
@@ -60,7 +61,7 @@ async fn sync_connection(
     let mut conn = pg_client.get_connection().await?;
 
     auth_state
-        .authorize_workspace(&mut conn, workspace.id, Permission::ManageConnections)
+        .authorize_workspace(&mut conn, workspace.id, Permission::RunConnectionSyncs)
         .await?;
 
     let connection = find_connection(&mut conn, workspace.id, path_params.connection_id).await?;
@@ -97,8 +98,7 @@ async fn sync_connection(
         SyncMode::Import => None,
     };
 
-    let credentials: serde_json::Value =
-        crypto.decrypt_json(workspace.id, &connection.encrypted_data)?;
+    let config: ConnectionConfig = crypto.decrypt_json(workspace.id, &connection.encrypted_data)?;
 
     let new_run = NewWorkspaceConnectionRun {
         connection_id: connection.id,
@@ -118,7 +118,7 @@ async fn sync_connection(
     let account_id = auth_state.account_id;
     tokio::spawn(async move {
         connection_sync
-            .run_transfer(run_id, connection, credentials, account_id, export)
+            .run_transfer(run_id, connection, config, account_id, export)
             .await;
     });
 
@@ -230,7 +230,7 @@ fn read_connection_sync_docs(op: TransformOperation) -> TransformOperation {
 /// that already finished is returned unchanged as a `409 Conflict`. The
 /// background transfer is bounded by the sync timeout and its completion is
 /// status-guarded, so a cancelled run is never overwritten. Requires
-/// `ManageConnections` permission.
+/// `RunConnectionSyncs` permission.
 #[tracing::instrument(
     skip_all,
     fields(
@@ -252,7 +252,7 @@ async fn cancel_connection_sync(
     let mut conn = pg_client.get_connection().await?;
 
     auth_state
-        .authorize_workspace(&mut conn, workspace.id, Permission::ManageConnections)
+        .authorize_workspace(&mut conn, workspace.id, Permission::RunConnectionSyncs)
         .await?;
 
     let connection = find_connection(&mut conn, workspace.id, path_params.connection_id).await?;

--- a/crates/nvisy-server/src/handler/connections.rs
+++ b/crates/nvisy-server/src/handler/connections.rs
@@ -17,6 +17,7 @@ use aide::axum::ApiRouter;
 use aide::transform::TransformOperation;
 use axum::extract::State;
 use axum::http::StatusCode;
+use nvisy_object::providers::ConnectionConfig;
 use nvisy_postgres::model::{
     NewWorkspaceConnection, UpdateWorkspaceConnection, WorkspaceConnection,
 };
@@ -80,13 +81,16 @@ async fn create_connection(
         }
     }
 
-    let encrypted_data = crypto.encrypt_json(workspace.id, &request.data)?;
+    // The provider column is derived from the typed config so the two can never
+    // disagree; the full config is encrypted at rest.
+    let provider = request.config.provider_id().to_owned();
+    let encrypted_data = crypto.encrypt_json(workspace.id, &request.config)?;
 
     let new_connection = NewWorkspaceConnection {
         workspace_id: workspace.id,
         account_id: auth_state.account_id,
         display_name: request.display_name,
-        provider: request.provider,
+        provider,
         sync_mode: Some(request.sync_mode),
         schedule_cron: request.schedule_cron,
         deletion_policy: Some(request.deletion_policy),
@@ -293,13 +297,19 @@ async fn update_connection(
         return Err(ErrorKind::BadRequest.with_message("Invalid cron expression"));
     }
 
-    let encrypted_data = request
-        .data
-        .map(|data| crypto.encrypt_json(workspace.id, &data))
-        .transpose()?;
+    // Replacing the config re-derives the provider column and re-encrypts the
+    // blob together, so they stay in lockstep.
+    let (provider, encrypted_data) = match &request.config {
+        Some(config) => (
+            Some(config.provider_id().to_owned()),
+            Some(crypto.encrypt_json(workspace.id, config)?),
+        ),
+        None => (None, None),
+    };
 
     let update_data = UpdateWorkspaceConnection {
         display_name: request.display_name,
+        provider,
         sync_mode: request.sync_mode,
         schedule_cron: request.schedule_cron,
         deletion_policy: request.deletion_policy,
@@ -382,7 +392,7 @@ fn delete_connection_docs(op: TransformOperation) -> TransformOperation {
 
 /// Verifies that a connection's backing object store is reachable.
 ///
-/// Decrypts the stored credentials and attempts a lightweight reachability
+/// Decrypts the stored connection config and attempts a lightweight reachability
 /// check against the provider. Returns `200` with a [`ConnectionVerification`]
 /// describing the outcome: a store that is reachable but rejects the
 /// credentials reports `reachable: false` with the reason, rather than an HTTP
@@ -414,10 +424,9 @@ async fn verify_connection(
     let (connection, _, _) =
         find_connection(&mut conn, workspace.id, path_params.connection_id).await?;
 
-    let credentials: serde_json::Value =
-        crypto.decrypt_json(workspace.id, &connection.encrypted_data)?;
+    let config: ConnectionConfig = crypto.decrypt_json(workspace.id, &connection.encrypted_data)?;
 
-    let verification = match object.connect(&connection.provider, credentials).await {
+    let verification = match object.connect(&config).await {
         Ok(client) => match client.verify_reachable().await {
             Ok(()) => {
                 tracing::info!(target: TRACING_TARGET, "Connection verified");

--- a/crates/nvisy-server/src/handler/request/connections.rs
+++ b/crates/nvisy-server/src/handler/request/connections.rs
@@ -1,5 +1,6 @@
 //! Connection request types.
 
+use nvisy_object::providers::ConnectionConfig;
 use nvisy_postgres::types::{ConnectionId, SyncDeletionPolicy, SyncMode};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -26,9 +27,6 @@ pub struct CreateConnection {
     /// Human-readable connection display name.
     #[validate(length(min = 1, max = 255))]
     pub display_name: String,
-    /// Object store provider (`s3`, `azure`, `gcs`).
-    #[validate(length(min = 1, max = 64))]
-    pub provider: String,
     /// Whether the connection imports data in or exports data out.
     #[serde(default)]
     pub sync_mode: SyncMode,
@@ -38,9 +36,10 @@ pub struct CreateConnection {
     /// How an import reconciles files whose source object was deleted.
     #[serde(default)]
     pub deletion_policy: SyncDeletionPolicy,
-    /// Connection data to be encrypted (provider credentials + optional root
-    /// path). The structure depends on the provider type.
-    pub data: serde_json::Value,
+    /// Typed provider configuration (provider tag + its credentials + optional
+    /// root path), encrypted at rest. The `provider` tag selects which
+    /// credential shape is required.
+    pub config: ConnectionConfig,
 }
 
 /// Request payload for updating an existing workspace connection.
@@ -58,9 +57,9 @@ pub struct UpdateConnection {
     pub schedule_cron: Option<Option<String>>,
     /// How an import reconciles files whose source object was deleted.
     pub deletion_policy: Option<SyncDeletionPolicy>,
-    /// Connection data to be encrypted (provider credentials + optional root
-    /// path). If provided, replaces the existing encrypted data.
-    pub data: Option<serde_json::Value>,
+    /// Typed provider configuration. If provided, fully replaces the stored
+    /// config (and, with it, the provider). Omit to leave it unchanged.
+    pub config: Option<ConnectionConfig>,
 }
 
 /// Query parameters for listing connections.

--- a/crates/nvisy-server/src/service/object/mod.rs
+++ b/crates/nvisy-server/src/service/object/mod.rs
@@ -1,11 +1,11 @@
 //! Object storage service.
 //!
 //! Bridges stored workspace connections to the [`nvisy_object`] providers: a
-//! connection carries a provider id (e.g. `s3`) and encrypted credential JSON,
-//! which this service turns into a connected [`ObjectStoreClient`] at runtime.
+//! connection carries an encrypted, typed [`ConnectionConfig`], which this
+//! service turns into a connected [`ObjectStoreClient`] at runtime.
 
 use nvisy_object::client::ObjectStoreClient;
-use nvisy_object::providers;
+use nvisy_object::providers::{self, ConnectionConfig};
 
 mod bridge;
 mod schedule;
@@ -33,20 +33,17 @@ impl ObjectService {
         Self
     }
 
-    /// Connects to the object store identified by `provider` using the given
-    /// decrypted credential JSON.
+    /// Connects to the object store described by the typed [`ConnectionConfig`].
     ///
     /// # Errors
     ///
-    /// Returns an error if the provider is unknown or the credentials do not
-    /// match the provider's expected shape or are rejected by the backend.
-    #[tracing::instrument(name = "object.connect", skip_all, fields(provider = %provider))]
+    /// Returns an error if the backend rejects the credentials.
+    #[tracing::instrument(name = "object.connect", skip_all, fields(provider = %config.provider_id()))]
     pub async fn connect(
         &self,
-        provider: &str,
-        credentials: serde_json::Value,
+        config: &ConnectionConfig,
     ) -> Result<ObjectStoreClient, nvisy_object::error::Error> {
         tracing::debug!(target: TRACING_TARGET, "Connecting to object store");
-        providers::connect(provider, credentials).await
+        providers::connect(config).await
     }
 }

--- a/crates/nvisy-server/src/service/object/sync.rs
+++ b/crates/nvisy-server/src/service/object/sync.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, Mutex};
 use nvisy_nats::NatsClient;
 use nvisy_nats::object::{FileKey, FilesBucket};
 use nvisy_object::client::ObjectStoreClient;
+use nvisy_object::providers::ConnectionConfig;
 use nvisy_postgres::PgClient;
 use nvisy_postgres::model::{NewWorkspaceFile, WorkspaceConnection, WorkspaceFile};
 use nvisy_postgres::query::{WorkspaceConnectionRunRepository, WorkspaceFileRepository};
@@ -103,15 +104,12 @@ impl ConnectionSyncService {
     pub async fn import_new(
         &self,
         connection: &WorkspaceConnection,
-        credentials: serde_json::Value,
+        config: &ConnectionConfig,
         account_id: Uuid,
     ) -> Result<u64> {
         tracing::debug!(target: TRACING_TARGET, "Importing new objects from connection");
 
-        let client = self
-            .object
-            .connect(&connection.provider, credentials)
-            .await?;
+        let client = self.object.connect(config).await?;
 
         // List the source once; keys are already scoped to the connection's root
         // path by the provider's PrefixStore. The listing is reused both to
@@ -331,16 +329,13 @@ impl ConnectionSyncService {
     pub async fn export_file(
         &self,
         connection: &WorkspaceConnection,
-        credentials: serde_json::Value,
+        config: &ConnectionConfig,
         file: &WorkspaceFile,
         remote_key: &str,
     ) -> Result<()> {
         tracing::debug!(target: TRACING_TARGET, "Exporting file to connection");
 
-        let client = self
-            .object
-            .connect(&connection.provider, credentials)
-            .await?;
+        let client = self.object.connect(config).await?;
 
         let store = self.nats.object_store::<FilesBucket>().await?;
         let file_key = FileKey::from_str(&file.storage_path).map_err(|err| {
@@ -381,7 +376,7 @@ impl ConnectionSyncService {
         &self,
         run_id: Uuid,
         connection: WorkspaceConnection,
-        credentials: serde_json::Value,
+        config: ConnectionConfig,
         account_id: Uuid,
         export: Option<(WorkspaceFile, String)>,
     ) {
@@ -394,13 +389,9 @@ impl ConnectionSyncService {
         let transfer = self.clone();
         let mut work = tokio::spawn(async move {
             match export {
-                None => {
-                    transfer
-                        .import_new(&connection, credentials, account_id)
-                        .await
-                }
+                None => transfer.import_new(&connection, &config, account_id).await,
                 Some((file, key)) => transfer
-                    .export_file(&connection, credentials, &file, &key)
+                    .export_file(&connection, &config, &file, &key)
                     .await
                     .map(|()| 1),
             }

--- a/crates/nvisy-server/src/service/object/worker.rs
+++ b/crates/nvisy-server/src/service/object/worker.rs
@@ -18,6 +18,7 @@ use jiff::{Span, Timestamp};
 use nvisy_nats::NatsClient;
 use nvisy_nats::kv::{LockKey, SchedulerLocksBucket};
 use nvisy_nats::stream::{ConnectionSyncStream, EventPublisher, EventSubscriber};
+use nvisy_object::providers::ConnectionConfig;
 use nvisy_postgres::PgClient;
 use nvisy_postgres::model::{
     NewWorkspaceConnectionRun, WorkspaceConnection, WorkspaceConnectionRun,
@@ -281,7 +282,7 @@ impl ConnectionSyncWorker {
             }
         }
 
-        let (credentials, run_id) = match self.begin_run(&connection, job.attempt).await {
+        let (config, run_id) = match self.begin_run(&connection, job.attempt).await {
             Ok(started) => started,
             Err(err) => {
                 // A concurrent run beat us to the unique index; treat as benign.
@@ -296,7 +297,7 @@ impl ConnectionSyncWorker {
         let connection_id = connection.id;
         let workspace_id = connection.workspace_id;
         self.sync
-            .run_transfer(run_id, connection, credentials, account_id, None)
+            .run_transfer(run_id, connection, config, account_id, None)
             .await;
 
         self.maybe_retry(workspace_id, connection_id, run_id, job.attempt, cancel)
@@ -398,14 +399,14 @@ impl ConnectionSyncWorker {
             .await?)
     }
 
-    /// Decrypts credentials and opens a `Scheduled` run for the connection at the
-    /// given attempt number.
+    /// Decrypts the connection config and opens a `Scheduled` run for the
+    /// connection at the given attempt number.
     async fn begin_run(
         &self,
         connection: &WorkspaceConnection,
         attempt: i32,
-    ) -> Result<(serde_json::Value, Uuid)> {
-        let credentials = self
+    ) -> Result<(ConnectionConfig, Uuid)> {
+        let config = self
             .crypto
             .decrypt_json(connection.workspace_id, &connection.encrypted_data)?;
 
@@ -420,6 +421,6 @@ impl ConnectionSyncWorker {
             metadata: None,
         };
         let run = conn.create_workspace_connection_run(new_run).await?;
-        Ok((credentials, run.id))
+        Ok((config, run.id))
     }
 }


### PR DESCRIPTION
Replaces the stringly-typed `provider: String` + untyped `data: serde_json::Value` on connections with a single, fully-typed `ConnectionConfig`, so a bad provider or malformed credentials are rejected at the API boundary instead of failing deep in the sync path at connect time.

## What changed
- **`ConnectionConfig`** — a `#[serde(tag = "provider")]` enum in `nvisy-object` with `S3` / `Azure` / `Gcs` variants. The tag drives which credential shape is required (an S3 connection can't carry Azure credentials).
- **Used end to end** — the request DTOs carry it, it's encrypted at rest, and `providers::connect(&ConnectionConfig)` replaces `connect(provider_str, Value)`, removing the runtime provider-string match on **both** the API and sync paths.
- **Single source of truth** — the DB `provider` column is derived from `config.provider_id()` in create/update, so column and blob can't drift.
- **`RunConnectionSyncs`** — a new Member-level permission (mirroring `RunPipelines`) for triggering/cancelling syncs; configuring connections and `verify` still require Admin `ManageConnections`.

## Wire shape
Nested and consistent across create and update:
```json
{ "displayName": "...", "syncMode": "import",
  "config": { "provider": "s3", "rootPath": "in/",
              "credentials": { "bucket": "b", "accessKeyId": "..." } } }
```
Uses serde `rename_all_fields` (honored by schemars 1.2.2, so OpenAPI stays consistent) — one container attribute, no per-variant duplication.

## ⚠️ Breaking changes
- **API contract**: `provider` + flat `data` → nested `config`.
- **Stored blob format**: the encrypted blob now holds the whole tagged config, not bare credential JSON. Existing connections (if any) must be re-created.

## Notes
- Credential structs gained `Serialize`/`Clone` only to persist the config encrypted; redacted `Debug` is unchanged and responses never expose credentials.
- Full gate green: check, clippy `-D warnings`, fmt, machete, doc `-D warnings`, full test suite (incl. new `ConnectionConfig` (de)serialization tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)