### PR TITLE
Reconcile sync/webhook worker observability and bounded retries

### DIFF
--- a/crates/nvisy-nats/src/stream/event_stream.rs
+++ b/crates/nvisy-nats/src/stream/event_stream.rs
@@ -24,6 +24,12 @@ pub trait EventStream: Clone + Send + Sync + 'static {
     /// expected processing time so a slow-but-healthy job is not redelivered
     /// and run a second time concurrently.
     const ACK_WAIT: Option<Duration> = None;
+
+    /// Maximum number of delivery attempts before the server stops redelivering a
+    /// message. `None` means unlimited (redeliver until the message ages out).
+    /// Set this to bound retries for consumers that nack on failure, so a
+    /// permanently-failing message is not redelivered indefinitely.
+    const MAX_DELIVER: Option<i64> = None;
 }
 
 /// Stream for webhook delivery.
@@ -35,6 +41,7 @@ pub struct WebhookStream;
 impl EventStream for WebhookStream {
     const CONSUMER_NAME: &'static str = "webhook-worker";
     const MAX_AGE: Option<Duration> = Some(Duration::from_secs(24 * 60 * 60));
+    const MAX_DELIVER: Option<i64> = Some(5);
     const NAME: &'static str = "WEBHOOKS";
     const SUBJECT: &'static str = "webhooks";
 }

--- a/crates/nvisy-nats/src/stream/event_sub.rs
+++ b/crates/nvisy-nats/src/stream/event_sub.rs
@@ -43,6 +43,7 @@ where
             S::CONSUMER_NAME,
             S::MAX_AGE,
             S::ACK_WAIT,
+            S::MAX_DELIVER,
             Some(format!("{}.>", S::NAME)),
         )
         .await?;

--- a/crates/nvisy-nats/src/stream/stream_sub.rs
+++ b/crates/nvisy-nats/src/stream/stream_sub.rs
@@ -19,6 +19,7 @@ struct StreamSubscriberInner {
     consumer_name: String,
     filter_subject: Option<String>,
     ack_wait: Option<Duration>,
+    max_deliver: Option<i64>,
 }
 
 /// Type-safe stream subscriber with compile-time guarantees.
@@ -47,6 +48,7 @@ where
         consumer_name: &str,
         max_age: Option<Duration>,
         ack_wait: Option<Duration>,
+        max_deliver: Option<i64>,
         filter_subject: Option<String>,
     ) -> Result<Self> {
         // Try to get existing stream, create if it doesn't exist
@@ -93,6 +95,7 @@ where
                 consumer_name: consumer_name.to_string(),
                 filter_subject,
                 ack_wait,
+                max_deliver,
             }),
             _marker: PhantomData,
         })
@@ -110,6 +113,10 @@ where
 
         if let Some(ack_wait) = self.inner.ack_wait {
             consumer_config.ack_wait = ack_wait;
+        }
+
+        if let Some(max_deliver) = self.inner.max_deliver {
+            consumer_config.max_deliver = max_deliver;
         }
 
         if let Some(filter) = &self.inner.filter_subject {
@@ -168,6 +175,10 @@ where
 
         if let Some(ack_wait) = self.inner.ack_wait {
             consumer_config.ack_wait = ack_wait;
+        }
+
+        if let Some(max_deliver) = self.inner.max_deliver {
+            consumer_config.max_deliver = max_deliver;
         }
 
         if let Some(filter) = &self.inner.filter_subject {

--- a/crates/nvisy-server/src/service/object/sync.rs
+++ b/crates/nvisy-server/src/service/object/sync.rs
@@ -149,7 +149,7 @@ impl ConnectionSyncService {
         self.reconcile_deletions(connection, account_id, &remote_keys)
             .await;
 
-        tracing::info!(target: TRACING_TARGET, imported, "Import sync complete");
+        tracing::debug!(target: TRACING_TARGET, imported, "Import sync complete");
         Ok(imported)
     }
 
@@ -357,7 +357,7 @@ impl ConnectionSyncService {
             .put_multipart(remote_key, file.mime_type.as_deref(), body)
             .await?;
 
-        tracing::info!(target: TRACING_TARGET, "File exported");
+        tracing::debug!(target: TRACING_TARGET, "File exported");
         Ok(())
     }
 

--- a/crates/nvisy-server/src/service/object/worker.rs
+++ b/crates/nvisy-server/src/service/object/worker.rs
@@ -98,11 +98,26 @@ impl ConnectionSyncWorker {
         }
     }
 
-    /// Runs the worker until cancelled: reaps stale runs, then drives the
-    /// scheduler tick and the job consumer concurrently.
+    /// Runs the worker until cancelled, logging its lifecycle (start, stop,
+    /// failure).
     pub async fn run(&self, cancel: CancellationToken) -> Result<()> {
         tracing::info!(target: TRACING_TARGET, "Starting connection sync worker");
 
+        let result = self.run_inner(cancel).await;
+
+        match &result {
+            Ok(()) => tracing::info!(target: TRACING_TARGET, "Connection sync worker stopped"),
+            Err(err) => {
+                tracing::error!(target: TRACING_TARGET, error = %err, "Connection sync worker failed")
+            }
+        }
+
+        result
+    }
+
+    /// Reaps stale runs, then drives the scheduler tick and the job consumer
+    /// concurrently until cancelled.
+    async fn run_inner(&self, cancel: CancellationToken) -> Result<()> {
         if let Err(err) = self.reap_stale_runs().await {
             tracing::error!(target: TRACING_TARGET, error = %err, "Failed to reap stale runs");
         }
@@ -221,7 +236,10 @@ impl ConnectionSyncWorker {
 
         loop {
             tokio::select! {
-                _ = cancel.cancelled() => break,
+                _ = cancel.cancelled() => {
+                    tracing::info!(target: TRACING_TARGET, "Connection sync worker shutdown requested");
+                    break;
+                }
                 result = stream.next_with_timeout(Duration::from_secs(5)) => {
                     match result {
                         Ok(Some(mut message)) => {

--- a/crates/nvisy-server/src/service/webhook/worker.rs
+++ b/crates/nvisy-server/src/service/webhook/worker.rs
@@ -153,7 +153,7 @@ impl WebhookWorker {
         })?;
 
         if response.is_success() {
-            tracing::info!(
+            tracing::debug!(
                 target: TRACING_TARGET,
                 request_id = %request.request_id,
                 webhook_id = %request.context.webhook_id,


### PR DESCRIPTION
Brings the two background workers to parity where they genuinely diverged, while leaving the intentional differences (retry model, ack_wait) alone.

## What was reconciled

**Lifecycle logging** — the connection sync worker only logged "start"; the webhook worker logged start/stop/fail/shutdown. Now at parity:
- `run()` wraps `run_inner()` with the same start/stopped/failed envelope.
- The consumer loop logs "shutdown requested" on cancel.

So a clean server shutdown (or a startup failure) is now visible for the sync worker instead of silent.

**Bounded webhook retries** — a permanently-failing webhook was `nack`'d and redelivered *forever* (until the 1-day age-out). Added `MAX_DELIVER` to the `EventStream` trait, set `Some(5)` on `WebhookStream`, threaded through the consumer config. This gives the webhook worker the bounded-retry guarantee the sync worker already had via its `attempt` cap.

**Tracing levels** — per-operation completions over-used `info!` compared to the handler convention (handlers use `debug!` for the operation, `info!` only for consequential state changes). Demoted to `debug!`: import-complete, file-exported, webhook-delivered-successfully. Kept at `info!`: deletions (guarded by `removed > 0`), retries, and lifecycle.

## Left intentionally divergent
The **retry model** stays different by design: webhook uses JetStream nack-redelivery (short, stateless); sync uses self-managed bounded re-enqueue with a DB `attempt` counter (long-running, stateful). `ack_wait` also correctly differs (webhook fast, sync 35 min).

## ⚠️ Operational note
`MAX_DELIVER` (like the existing `ACK_WAIT`) is applied only when the consumer is **created** — `get_or_create_consumer` returns an existing consumer unchanged. An environment where the `webhook-worker` consumer already exists must have that consumer recreated to pick up the new bound; new environments get it immediately.

Full gate green: check, clippy `-D warnings`, fmt, machete, doc `-D warnings`, full test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)