### PR TITLE
Update runtime (pulls elide schema renames); fix Page/SortBy schema names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1675,7 +1675,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -1695,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "elide-bento"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#d694a32b2b15101d055aa0e4041e3b57cd1df6de"
+source = "git+https://github.com/nvisycom/runtime?branch=main#1b83bef1adedc82f9a6d6a42561e654ca1b9a542"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -1711,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1808,7 +1808,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -1822,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -1832,7 +1832,7 @@ dependencies = [
 [[package]]
 name = "elide-orchestration"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -1846,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1881,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#97d03a75dc303188db6e40243386c7ca40e941e3"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -3677,7 +3677,7 @@ dependencies = [
 [[package]]
 name = "nvisy-engine"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#d694a32b2b15101d055aa0e4041e3b57cd1df6de"
+source = "git+https://github.com/nvisycom/runtime?branch=main#1b83bef1adedc82f9a6d6a42561e654ca1b9a542"
 dependencies = [
  "bytes",
  "derive_builder",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "nvisy-policy"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#d694a32b2b15101d055aa0e4041e3b57cd1df6de"
+source = "git+https://github.com/nvisycom/runtime?branch=main#1b83bef1adedc82f9a6d6a42561e654ca1b9a542"
 dependencies = [
  "derive_more",
  "elide-core",
@@ -3777,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "nvisy-schema"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#d694a32b2b15101d055aa0e4041e3b57cd1df6de"
+source = "git+https://github.com/nvisycom/runtime?branch=main#1b83bef1adedc82f9a6d6a42561e654ca1b9a542"
 dependencies = [
  "bytes",
  "elide-core",

--- a/crates/nvisy-postgres/src/types/sorting/mod.rs
+++ b/crates/nvisy-postgres/src/types/sorting/mod.rs
@@ -26,6 +26,7 @@ pub enum SortOrder {
 /// Generic sort specification with field and order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(feature = "schema", schemars(rename = "Sort{F}"))]
 pub struct SortBy<F> {
     /// The field to sort by.
     pub field: F,

--- a/crates/nvisy-server/src/handler/response/mod.rs
+++ b/crates/nvisy-server/src/handler/response/mod.rs
@@ -48,7 +48,7 @@ pub use workspaces::*;
 /// cursor-based pagination support. When `next_cursor` is present, there
 /// are more items to fetch.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(rename = "{T}sPage")]
+#[schemars(rename = "{T}Page")]
 #[serde(rename_all = "camelCase")]
 pub struct Page<T> {
     /// Items in this page.


### PR DESCRIPTION
## Runtime bump
Bumps `nvisy-engine` / `nvisy-policy` / `nvisy-schema` to `1b83bef1`, which re-pins `elide` to `5f613868`. That brings in [elide#137](https://github.com/nvisycom/elide/pull/137): elide's generic `JsonSchema` types (`Provenance<M>`, `Entity<M>`, `Event<M>`, …) now get modality-prefixed names (`TextProvenance`, `ImageEntity`, …) instead of colliding into meaningless `Provenance2/3/4` in the OpenAPI document. elide is transitive via the runtime, so the runtime bump is what pulls it in.

## Same-issue audit in our code
Checked our own generic types deriving `JsonSchema` for the identical schemars base-name collision:

- **`Page<T>`** — the one real collision candidate (15 concrete instantiations, all on the OpenAPI surface). It was already renamed, but the `"{T}sPage"` template pluralized naively — `Page<Activity>` → `ActivitysPage`, `Page<Policy>` → `PolicysPage`. Switched to **`"{T}Page"`** → `ActivityPage`, `PolicyPage`, `ConnectionPage`: grammatically correct for every type, no pluralization guesswork. (Verified the generated names empirically.)
- **`SortBy<F>`** — derives `JsonSchema` but is an internal query type, **not** on the OpenAPI surface, so it can't currently collide. Added `schemars(rename = "Sort{F}")` **defensively** so it stays unique if ever exposed.
- **`ErrorResponse<'a>`** — lifetime-only, cannot collide. No other generic `JsonSchema` types exist.

## Verification
Full gate green: check, clippy `-D warnings`, fmt, machete, doc `-D warnings`, full test suite. Confirmed the corrected `Page` names (`ActivityPage`, `PolicyPage`, `ConnectionPage`) via a throwaway schema-name check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)