### PR TITLE
Workspace sync list, connection enable/disable, multi-provider filters, quieter logging

### DIFF
--- a/crates/nvisy-nats/src/kv/kv_store.rs
+++ b/crates/nvisy-nats/src/kv/kv_store.rs
@@ -55,7 +55,7 @@ where
 
         let store = match jetstream.get_key_value(B::NAME).await {
             Ok(store) => {
-                tracing::debug!(
+                tracing::trace!(
                     target: TRACING_TARGET_KV,
                     bucket = %B::NAME,
                     "Using existing KV bucket"

--- a/crates/nvisy-nats/src/stream/stream_pub.rs
+++ b/crates/nvisy-nats/src/stream/stream_pub.rs
@@ -46,7 +46,7 @@ where
         // Try to get existing stream first
         match jetstream.get_stream(stream_name).await {
             Ok(_) => {
-                tracing::debug!(
+                tracing::trace!(
                     target: TRACING_TARGET_STREAM,
                     stream = %stream_name,
                     type_name = std::any::type_name::<T>(),

--- a/crates/nvisy-nats/src/stream/stream_sub.rs
+++ b/crates/nvisy-nats/src/stream/stream_sub.rs
@@ -54,7 +54,7 @@ where
         // Try to get existing stream, create if it doesn't exist
         match jetstream.get_stream(stream_name).await {
             Ok(_) => {
-                tracing::debug!(
+                tracing::trace!(
                     target: TRACING_TARGET_STREAM,
                     stream = %stream_name,
                     consumer = %consumer_name,

--- a/crates/nvisy-postgres/src/client/custom_hooks.rs
+++ b/crates/nvisy-postgres/src/client/custom_hooks.rs
@@ -111,7 +111,7 @@ pub fn post_create(conn: &mut AsyncPgConnection, metrics: &Metrics) -> HookResul
 pub fn pre_recycle(conn: &mut AsyncPgConnection, metrics: &Metrics) -> HookResult<PoolError> {
     let is_broken = conn.is_broken();
 
-    tracing::debug!(
+    tracing::trace!(
         target: TRACING_TARGET_CONNECTION,
         hook = "pre_recycle",
         is_broken = is_broken,
@@ -142,7 +142,7 @@ pub fn pre_recycle(conn: &mut AsyncPgConnection, metrics: &Metrics) -> HookResul
 pub fn post_recycle(conn: &mut AsyncPgConnection, metrics: &Metrics) -> HookResult<PoolError> {
     let is_broken = conn.is_broken();
 
-    tracing::debug!(
+    tracing::trace!(
         target: TRACING_TARGET_CONNECTION,
         hook = "post_recycle",
         is_broken = is_broken,

--- a/crates/nvisy-postgres/src/client/pg_client.rs
+++ b/crates/nvisy-postgres/src/client/pg_client.rs
@@ -178,7 +178,7 @@ impl PgClient {
     /// Returns an error if no connection is available within the timeout period.
     #[tracing::instrument(skip(self), target = TRACING_TARGET_CONNECTION)]
     pub async fn get_connection(&self) -> PgResult<PgConn> {
-        tracing::debug!(target: TRACING_TARGET_CONNECTION, "Acquiring connection from pool");
+        tracing::trace!(target: TRACING_TARGET_CONNECTION, "Acquiring connection from pool");
 
         let start = Instant::now();
         let conn = self.inner.pool.get().await.map_err(|e| {
@@ -200,7 +200,7 @@ impl PgClient {
             );
         }
 
-        tracing::debug!(target: TRACING_TARGET_CONNECTION, elapsed = ?elapsed, "Connection acquired successfully");
+        tracing::trace!(target: TRACING_TARGET_CONNECTION, elapsed = ?elapsed, "Connection acquired successfully");
         Ok(PgConn::new(conn))
     }
 

--- a/crates/nvisy-postgres/src/query/workspace_connection.rs
+++ b/crates/nvisy-postgres/src/query/workspace_connection.rs
@@ -68,11 +68,14 @@ pub trait WorkspaceConnectionRepository {
 
     /// Lists all connections in a workspace with cursor pagination, each paired
     /// with the handle of the account that created it.
+    ///
+    /// An empty `providers` slice means no provider filter; otherwise a
+    /// connection matches if its provider is any of the given ones.
     fn cursor_list_workspace_connections(
         &mut self,
         workspace_id: Uuid,
         pagination: CursorPagination,
-        provider_filter: Option<&str>,
+        providers: &[String],
     ) -> impl Future<Output = PgResult<CursorPage<(WorkspaceConnection, Handle)>>> + Send;
 
     /// Updates a connection with new data.
@@ -240,7 +243,7 @@ impl WorkspaceConnectionRepository for PgConnection {
         &mut self,
         workspace_id: Uuid,
         pagination: CursorPagination,
-        provider_filter: Option<&str>,
+        providers: &[String],
     ) -> PgResult<CursorPage<(WorkspaceConnection, Handle)>> {
         use schema::workspace_connections::dsl;
         use schema::{accounts, workspace_connections};
@@ -251,9 +254,9 @@ impl WorkspaceConnectionRepository for PgConnection {
             .filter(dsl::deleted_at.is_null())
             .into_boxed();
 
-        // Apply provider filter
-        if let Some(provider) = provider_filter {
-            base_query = base_query.filter(dsl::provider.eq(provider));
+        // Apply provider filter (any-of)
+        if !providers.is_empty() {
+            base_query = base_query.filter(dsl::provider.eq_any(providers.to_vec()));
         }
 
         let total = if pagination.include_count {
@@ -275,8 +278,8 @@ impl WorkspaceConnectionRepository for PgConnection {
             .filter(dsl::deleted_at.is_null())
             .into_boxed();
 
-        if let Some(provider) = provider_filter {
-            query = query.filter(dsl::provider.eq(provider));
+        if !providers.is_empty() {
+            query = query.filter(dsl::provider.eq_any(providers.to_vec()));
         }
 
         let limit = pagination.fetch_limit();

--- a/crates/nvisy-postgres/src/query/workspace_connection_run.rs
+++ b/crates/nvisy-postgres/src/query/workspace_connection_run.rs
@@ -77,7 +77,8 @@ pub trait WorkspaceConnectionRunRepository {
     ///
     /// Runs carry no workspace reference of their own, so this joins through the
     /// owning connection and filters on its workspace. An optional status filter
-    /// narrows the result; use [`cursor_list_workspace_connection_runs`] for a
+    /// and a set of providers narrow the result; an empty `providers` slice means
+    /// no provider filter. Use [`cursor_list_workspace_connection_runs`] for a
     /// single connection.
     ///
     /// [`cursor_list_workspace_connection_runs`]: Self::cursor_list_workspace_connection_runs
@@ -86,6 +87,7 @@ pub trait WorkspaceConnectionRunRepository {
         workspace_id: Uuid,
         pagination: CursorPagination,
         status_filter: Option<SyncStatus>,
+        providers: &[String],
     ) -> impl Future<Output = PgResult<CursorPage<(WorkspaceConnectionRun, Uuid, Option<Handle>)>>> + Send;
 
     /// Gets the most recent run for a connection (its current sync state).
@@ -328,6 +330,7 @@ impl WorkspaceConnectionRunRepository for PgConnection {
         workspace_id: Uuid,
         pagination: CursorPagination,
         status_filter: Option<SyncStatus>,
+        providers: &[String],
     ) -> PgResult<CursorPage<(WorkspaceConnectionRun, Uuid, Option<Handle>)>> {
         use schema::accounts::dsl as accounts;
         use schema::workspace_connection_runs::dsl as runs;
@@ -345,6 +348,9 @@ impl WorkspaceConnectionRunRepository for PgConnection {
                 .into_boxed();
             if let Some(status) = status_filter {
                 query = query.filter(runs::status.eq(status));
+            }
+            if !providers.is_empty() {
+                query = query.filter(connections::provider.eq_any(providers.to_vec()));
             }
             query
         };

--- a/crates/nvisy-server/src/handler/connection_syncs.rs
+++ b/crates/nvisy-server/src/handler/connection_syncs.rs
@@ -25,6 +25,7 @@ use crate::extract::{
 };
 use crate::handler::request::{
     ConnectionPathParams, ConnectionSyncPathParams, CursorPagination, SyncConnection,
+    WorkspaceSyncsQuery,
 };
 use crate::handler::response::{ConnectionSync, ConnectionSyncsPage, ErrorResponse, Page};
 use crate::handler::{Error, ErrorKind, Result};
@@ -179,6 +180,61 @@ fn list_connection_syncs_docs(op: TransformOperation) -> TransformOperation {
         .response::<404, Json<ErrorResponse>>()
 }
 
+/// Lists sync runs across every connection in the workspace, most recent first.
+///
+/// Optional `status` and repeatable `provider` query filters narrow the result
+/// (a sync matches if its connection uses any of the given providers). Requires
+/// `ViewConnections` permission.
+#[tracing::instrument(
+    skip_all,
+    fields(
+        account_id = %auth_state.account_id,
+        workspace_id = %workspace.id,
+    )
+)]
+async fn list_workspace_syncs(
+    State(pg_client): State<PgClient>,
+    AuthState(auth_state): AuthState,
+    WorkspaceContext(workspace): WorkspaceContext,
+    Query(pagination): Query<CursorPagination>,
+    Query(query): Query<WorkspaceSyncsQuery>,
+) -> Result<(StatusCode, Json<ConnectionSyncsPage>)> {
+    tracing::debug!(target: TRACING_TARGET, "Listing workspace syncs");
+
+    let mut conn = pg_client.get_connection().await?;
+
+    auth_state
+        .authorize_workspace(&mut conn, workspace.id, Permission::ViewConnections)
+        .await?;
+
+    let page = conn
+        .cursor_list_workspace_connection_runs_all(
+            workspace.id,
+            pagination.into(),
+            query.status,
+            &query.provider,
+        )
+        .await?;
+
+    let page = Page::from_cursor_page(page, |(run, _connection_id, _creator)| {
+        ConnectionSync::from_model(run)
+    });
+
+    Ok((StatusCode::OK, Json(page)))
+}
+
+fn list_workspace_syncs_docs(op: TransformOperation) -> TransformOperation {
+    op.summary("List workspace syncs")
+        .description(
+            "Returns all sync runs across the workspace's connections, most recent first, \
+             with optional status and provider filters.",
+        )
+        .response::<200, Json<ConnectionSyncsPage>>()
+        .response::<401, Json<ErrorResponse>>()
+        .response::<403, Json<ErrorResponse>>()
+        .response::<404, Json<ErrorResponse>>()
+}
+
 /// Retrieves a single sync run for a connection.
 #[tracing::instrument(
     skip_all,
@@ -305,6 +361,10 @@ pub fn routes() -> ApiRouter<ServiceState> {
     use aide::axum::routing::*;
 
     ApiRouter::new()
+        .api_route(
+            "/workspaces/{workspaceSlug}/syncs/",
+            get_with(list_workspace_syncs, list_workspace_syncs_docs),
+        )
         .api_route(
             "/workspaces/{workspaceSlug}/connections/{connectionId}/sync/",
             post_with(sync_connection, sync_connection_docs),

--- a/crates/nvisy-server/src/handler/connections.rs
+++ b/crates/nvisy-server/src/handler/connections.rs
@@ -95,7 +95,7 @@ async fn create_connection(
         schedule_cron: request.schedule_cron,
         deletion_policy: Some(request.deletion_policy),
         encrypted_data,
-        is_active: None,
+        is_active: request.is_active,
         metadata: None,
     };
 
@@ -163,11 +163,7 @@ async fn list_connections(
         .await?;
 
     let page = conn
-        .cursor_list_workspace_connections(
-            workspace.id,
-            pagination.into(),
-            query.provider.as_deref(),
-        )
+        .cursor_list_workspace_connections(workspace.id, pagination.into(), &query.provider)
         .await?;
 
     // One grouped query resolves last-synced for the whole page (not per row).
@@ -313,6 +309,7 @@ async fn update_connection(
         sync_mode: request.sync_mode,
         schedule_cron: request.schedule_cron,
         deletion_policy: request.deletion_policy,
+        is_active: request.is_active,
         encrypted_data,
         ..Default::default()
     };

--- a/crates/nvisy-server/src/handler/request/connection_syncs.rs
+++ b/crates/nvisy-server/src/handler/request/connection_syncs.rs
@@ -1,10 +1,23 @@
 //! Connection sync request types.
 
-use nvisy_postgres::types::ConnectionId;
+use nvisy_postgres::types::{ConnectionId, SyncStatus};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use validator::Validate;
+
+/// Query parameters for listing all syncs across a workspace.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceSyncsQuery {
+    /// Filter by sync status.
+    pub status: Option<SyncStatus>,
+    /// Filter by connection provider (`s3`, `azure`, `gcs`). Repeatable; a sync
+    /// matches if its connection uses any of the given providers. Empty means no
+    /// provider filter.
+    #[serde(default)]
+    pub provider: Vec<String>,
+}
 
 /// Path parameters for a specific connection sync.
 #[must_use]

--- a/crates/nvisy-server/src/handler/request/connections.rs
+++ b/crates/nvisy-server/src/handler/request/connections.rs
@@ -36,6 +36,9 @@ pub struct CreateConnection {
     /// How an import reconciles files whose source object was deleted.
     #[serde(default)]
     pub deletion_policy: SyncDeletionPolicy,
+    /// Whether the connection is enabled for syncing. Omit to default to active;
+    /// set `false` to create it disabled.
+    pub is_active: Option<bool>,
     /// Typed provider configuration (provider tag + its credentials + optional
     /// root path), encrypted at rest. The `provider` tag selects which
     /// credential shape is required.
@@ -57,6 +60,10 @@ pub struct UpdateConnection {
     pub schedule_cron: Option<Option<String>>,
     /// How an import reconciles files whose source object was deleted.
     pub deletion_policy: Option<SyncDeletionPolicy>,
+    /// Whether the connection is enabled for syncing. `false` disables it
+    /// (pausing scheduled syncs and rejecting manual ones); omit to leave
+    /// unchanged.
+    pub is_active: Option<bool>,
     /// Typed provider configuration. If provided, fully replaces the stored
     /// config (and, with it, the provider). Omit to leave it unchanged.
     pub config: Option<ConnectionConfig>,
@@ -66,6 +73,8 @@ pub struct UpdateConnection {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectionsQuery {
-    /// Filter by provider type.
-    pub provider: Option<String>,
+    /// Filter by provider (`s3`, `azure`, `gcs`). Repeatable; a connection
+    /// matches if it uses any of the given providers. Empty means no filter.
+    #[serde(default)]
+    pub provider: Vec<String>,
 }

--- a/crates/nvisy-server/src/handler/response/connections.rs
+++ b/crates/nvisy-server/src/handler/response/connections.rs
@@ -32,6 +32,8 @@ pub struct Connection {
     pub schedule_cron: Option<String>,
     /// How an import reconciles files whose source object was deleted.
     pub deletion_policy: SyncDeletionPolicy,
+    /// Whether the connection is enabled for syncing.
+    pub is_active: bool,
     /// When the connection last synced successfully, if ever.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_synced: Option<Timestamp>,
@@ -90,6 +92,7 @@ impl Connection {
             sync_mode: connection.sync_mode,
             schedule_cron: connection.schedule_cron,
             deletion_policy: connection.deletion_policy,
+            is_active: connection.is_active,
             last_synced,
             created_at: connection.created_at.into(),
             updated_at: connection.updated_at.into(),


### PR DESCRIPTION
Connection/sync improvements plus a logging-noise pass.

## Workspace-wide sync list
`GET /workspaces/{workspaceSlug}/syncs/` — all sync runs across every connection in the workspace, cursor-paginated, most recent first. Mirrors the pipeline `/workspaces/{slug}/runs/` endpoint. Filters: `?status=…` and repeatable `?provider=azure&provider=gcs` (matches any of). Wires up the previously-unused `cursor_list_workspace_connection_runs_all`. Requires `ViewConnections`.

## Consistent multi-provider filter
Audited every list/filter query param for single-vs-multi inconsistency. `provider` was the only field multi-valued in one place and single in another: the new syncs list did any-of, but `listConnections` took a single `Option<String>`. **Upgraded `listConnections` to the same repeatable `Vec<String>` + `eq_any`**, so `?provider=azure&provider=gcs` works on both. (Other single-valued filters — `role`, `status` — are consistently single everywhere, so left as-is.)

## Connection enable/disable
`is_active` was enforced internally (scheduler skips inactive connections; manual sync rejects them) but had no API path to toggle or read it. Now settable on **create** (start disabled) and **update** (pause without clearing the cron), and returned in the connection **response**.

## Quieter logging
Demoted routine per-request/per-tick logs from `debug!` to `trace!`:
- `get_connection` acquire/acquired (every DB op)
- `pre_recycle` / `post_recycle` pool hooks (every connection reuse)
- "Using existing" KV-bucket and stream resolution (every scheduler tick)

Kept at `debug!`: the infrequent "Creating new" bucket/stream logs. Unchanged: `warn!` (slow acquire) and `error!` (failures).

Note: the per-tick "Using existing" resolution reflects the scheduler rebuilding its KV/publisher handles each tick — quieted here; caching those handles is a reasonable follow-up efficiency win, not included.

## Verification
Full gate green: check, clippy `-D warnings`, fmt, machete, doc `-D warnings`, full test suite. Repeatable `provider` works via the project's `axum_extra`-backed `Query` extractor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)