### PR TITLE
Update runtime; PolicyDefinition rename, drop policy version, add PolicySummary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "elide-bento"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#1b83bef1adedc82f9a6d6a42561e654ca1b9a542"
+source = "git+https://github.com/nvisycom/runtime?branch=main#e2fde94c2bf2dda74c4bc9235f3d9b81ef8bb4a7"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -1777,6 +1777,17 @@ dependencies = [
  "schemars",
  "serde",
  "tracing",
+]
+
+[[package]]
+name = "elide-fake"
+version = "0.1.0"
+source = "git+https://github.com/nvisycom/elide?branch=main#5f613868a84b6f862b8b4874b62bfd7a495a394c"
+dependencies = [
+ "async-trait",
+ "elide-core",
+ "fake",
+ "uuid",
 ]
 
 [[package]]
@@ -1877,6 +1888,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "elide-core",
+ "elide-fake",
  "hex",
  "hipstr",
  "sha2 0.11.0",
@@ -2051,6 +2063,17 @@ name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
+name = "fake"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6be833b323a56361118a747470a45a1bcd5c52a2ec9b1e40c83dafe687e453"
+dependencies = [
+ "deunicode",
+ "either",
+ "rand 0.10.2",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -3706,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "nvisy-engine"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#1b83bef1adedc82f9a6d6a42561e654ca1b9a542"
+source = "git+https://github.com/nvisycom/runtime?branch=main#e2fde94c2bf2dda74c4bc9235f3d9b81ef8bb4a7"
 dependencies = [
  "bytes",
  "derive_builder",
@@ -3761,13 +3784,12 @@ dependencies = [
 [[package]]
 name = "nvisy-policy"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#1b83bef1adedc82f9a6d6a42561e654ca1b9a542"
+source = "git+https://github.com/nvisycom/runtime?branch=main#e2fde94c2bf2dda74c4bc9235f3d9b81ef8bb4a7"
 dependencies = [
  "derive_more",
  "elide-core",
  "hipstr",
  "schemars",
- "semver",
  "serde",
  "strum 0.28.0",
  "uuid",
@@ -3806,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "nvisy-schema"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#1b83bef1adedc82f9a6d6a42561e654ca1b9a542"
+source = "git+https://github.com/nvisycom/runtime?branch=main#e2fde94c2bf2dda74c4bc9235f3d9b81ef8bb4a7"
 dependencies = [
  "bytes",
  "elide-core",
@@ -5246,10 +5268,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "send_wrapper"

--- a/crates/nvisy-postgres/src/model/workspace_policy.rs
+++ b/crates/nvisy-postgres/src/model/workspace_policy.rs
@@ -28,8 +28,6 @@ pub struct WorkspacePolicy {
     pub display_name: String,
     /// Policy description.
     pub description: Option<String>,
-    /// Semver of the policy body.
-    pub version: String,
     /// Encrypted Policy body (the engine's Policy type as JSON).
     pub definition: Vec<u8>,
     /// Metadata for filtering/display.
@@ -57,8 +55,6 @@ pub struct NewWorkspacePolicy {
     pub display_name: String,
     /// Policy description.
     pub description: Option<String>,
-    /// Semver of the policy body.
-    pub version: String,
     /// Encrypted Policy body (the engine's Policy type as JSON).
     pub definition: Vec<u8>,
     /// Metadata for filtering/display.
@@ -74,8 +70,6 @@ pub struct UpdateWorkspacePolicy {
     pub display_name: Option<String>,
     /// Policy description.
     pub description: Option<Option<String>>,
-    /// Semver of the policy body.
-    pub version: Option<String>,
     /// Encrypted Policy body (the engine's Policy type as JSON).
     pub definition: Option<Vec<u8>>,
     /// Metadata for filtering/display.

--- a/crates/nvisy-postgres/src/schema.rs
+++ b/crates/nvisy-postgres/src/schema.rs
@@ -333,7 +333,6 @@ diesel::table! {
         slug -> Text,
         display_name -> Text,
         description -> Nullable<Text>,
-        version -> Text,
         definition -> Bytea,
         metadata -> Jsonb,
         created_at -> Timestamptz,

--- a/crates/nvisy-server/src/handler/pipeline_runs.rs
+++ b/crates/nvisy-server/src/handler/pipeline_runs.rs
@@ -12,7 +12,7 @@ use aide::transform::TransformOperation;
 use axum::extract::State;
 use axum::http::StatusCode;
 use bytes::Bytes;
-use nvisy_engine::policy::Policy as SchemaPolicy;
+use nvisy_engine::policy::PolicyDefinition as SchemaPolicy;
 use nvisy_engine::{AnalyzedDocument, Document};
 use nvisy_nats::NatsClient;
 use nvisy_nats::object::{FileKey, FilesBucket, IntermediateKey, IntermediatesBucket};

--- a/crates/nvisy-server/src/handler/policies.rs
+++ b/crates/nvisy-server/src/handler/policies.rs
@@ -20,7 +20,7 @@ use crate::extract::{
     AuthProvider, AuthState, Json, Path, Permission, Query, ValidateJson, WorkspaceContext,
 };
 use crate::handler::request::{CreatePolicy, CursorPagination, PolicyPathParams, UpdatePolicy};
-use crate::handler::response::{ErrorResponse, PoliciesPage, Policy};
+use crate::handler::response::{ErrorResponse, PoliciesPage, Policy, PolicySummary};
 use crate::handler::utility::resolve_creator_username;
 use crate::handler::{Error, Result};
 use crate::service::{CryptoService, ServiceState};
@@ -30,9 +30,9 @@ const TRACING_TARGET: &str = "nvisy_server::handler::policies";
 
 /// Creates a new workspace policy.
 ///
-/// The request body carries a structured policy definition; its name,
-/// description, and version drive the stored record unless overridden.
-/// Requires `ManagePolicies` permission for the workspace.
+/// The request body carries a structured policy definition; its name and
+/// description drive the stored record unless overridden. Requires
+/// `ManagePolicies` permission for the workspace.
 #[tracing::instrument(
     skip_all,
     fields(
@@ -62,7 +62,6 @@ async fn create_policy(
     let description = request
         .description
         .or_else(|| definition.description.clone());
-    let version = definition.version.to_string();
     let encrypted = crypto.encrypt_json(workspace.id, definition)?;
 
     let new_policy = NewWorkspacePolicy {
@@ -71,7 +70,6 @@ async fn create_policy(
         slug: request.slug,
         display_name,
         description,
-        version,
         definition: encrypted,
         metadata: None,
     };
@@ -113,7 +111,6 @@ fn create_policy_docs(op: TransformOperation) -> TransformOperation {
 )]
 async fn list_policies(
     State(pg_client): State<PgClient>,
-    State(crypto): State<CryptoService>,
     AuthState(auth_state): AuthState,
     WorkspaceContext(workspace): WorkspaceContext,
     Query(pagination): Query<CursorPagination>,
@@ -136,9 +133,11 @@ async fn list_policies(
         "Workspace policies listed",
     );
 
-    let page = PoliciesPage::try_from_cursor_page(page, |(model, creator_username)| {
-        Policy::from_model(model, workspace.slug.clone(), creator_username, &crypto)
-    })?;
+    // The list carries only metadata; the encrypted definition is decrypted only
+    // by the single-policy endpoint, so a page costs no per-item decryption.
+    let page = PoliciesPage::from_cursor_page(page, |(model, creator_username)| {
+        PolicySummary::from_model(model, workspace.slug.clone(), creator_username)
+    });
 
     Ok((StatusCode::OK, Json(page)))
 }
@@ -203,7 +202,7 @@ fn read_policy_docs(op: TransformOperation) -> TransformOperation {
 /// Updates a workspace policy.
 ///
 /// All fields are optional; replacing the definition replaces the whole
-/// policy body (and its version). Requires `ManagePolicies` permission.
+/// policy body. Requires `ManagePolicies` permission.
 #[tracing::instrument(
     skip_all,
     fields(
@@ -231,18 +230,14 @@ async fn update_policy(
     // Confirm the policy exists in this workspace before mutating.
     let (existing, _) = find_policy(&mut conn, workspace.id, &path_params.policy_slug).await?;
 
-    let (version, definition) = match &request.definition {
-        Some(definition) => {
-            let encrypted = crypto.encrypt_json(workspace.id, definition)?;
-            (Some(definition.version.to_string()), Some(encrypted))
-        }
-        None => (None, None),
+    let definition = match &request.definition {
+        Some(definition) => Some(crypto.encrypt_json(workspace.id, definition)?),
+        None => None,
     };
 
     let updates = UpdateWorkspacePolicy {
         display_name: request.display_name,
         description: request.description,
-        version,
         definition,
         ..Default::default()
     };

--- a/crates/nvisy-server/src/handler/request/policies.rs
+++ b/crates/nvisy-server/src/handler/request/policies.rs
@@ -1,6 +1,6 @@
 //! Policy request types.
 
-use nvisy_engine::policy::Policy as SchemaPolicy;
+use nvisy_engine::policy::PolicyDefinition as SchemaPolicy;
 use nvisy_postgres::types::Handle;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -23,8 +23,8 @@ pub struct PolicyPathParams {
 /// Request payload for creating a new workspace policy.
 ///
 /// The `definition` is a structured policy the redaction engine consumes;
-/// its `name`, `description`, and `version` drive the stored columns unless
-/// overridden here.
+/// its `name` and `description` drive the stored columns unless overridden
+/// here.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct CreatePolicy {

--- a/crates/nvisy-server/src/handler/response/policies.rs
+++ b/crates/nvisy-server/src/handler/response/policies.rs
@@ -1,7 +1,7 @@
 //! Policy response types.
 
 use jiff::Timestamp;
-use nvisy_engine::policy::Policy as SchemaPolicy;
+use nvisy_engine::policy::PolicyDefinition as SchemaPolicy;
 use nvisy_postgres::model::WorkspacePolicy;
 use nvisy_postgres::types::Handle;
 use schemars::JsonSchema;
@@ -25,8 +25,6 @@ pub struct Policy {
     /// Policy description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    /// Semver of the policy body.
-    pub version: String,
     /// The structured policy body consumed by the engine.
     pub definition: SchemaPolicy,
     /// When the policy was created.
@@ -35,8 +33,53 @@ pub struct Policy {
     pub updated_at: Timestamp,
 }
 
-/// Paginated list of policies.
-pub type PoliciesPage = Page<Policy>;
+/// Lightweight policy view for lists.
+///
+/// Carries only the metadata available without decrypting the policy body, so a
+/// page of policies costs no per-item decryption. The full [`Policy`] (with its
+/// `definition`) is returned by the single-policy endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicySummary {
+    /// URL slug of the policy, unique within its workspace.
+    pub slug: Handle,
+    /// Handle of the workspace this policy belongs to.
+    pub workspace_slug: Handle,
+    /// Handle of the account that created this policy.
+    pub creator_username: Handle,
+    /// Human-readable policy display name.
+    pub display_name: String,
+    /// Policy description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// When the policy was created.
+    pub created_at: Timestamp,
+    /// When the policy was last updated.
+    pub updated_at: Timestamp,
+}
+
+impl PolicySummary {
+    /// Creates a summary from a database model and its creator's handle. Does not
+    /// touch the encrypted definition.
+    pub fn from_model(
+        policy: WorkspacePolicy,
+        workspace_slug: Handle,
+        creator_username: Handle,
+    ) -> Self {
+        Self {
+            slug: policy.slug,
+            workspace_slug,
+            creator_username,
+            display_name: policy.display_name,
+            description: policy.description,
+            created_at: policy.created_at.into(),
+            updated_at: policy.updated_at.into(),
+        }
+    }
+}
+
+/// Paginated list of policy summaries.
+pub type PoliciesPage = Page<PolicySummary>;
 
 impl Policy {
     /// Creates a response from a database model and its creator's handle,
@@ -56,7 +99,6 @@ impl Policy {
             creator_username,
             display_name: policy.display_name,
             description: policy.description,
-            version: policy.version,
             definition,
             created_at: policy.created_at.into(),
             updated_at: policy.updated_at.into(),

--- a/migrations/2026-01-19-045015_policies/up.sql
+++ b/migrations/2026-01-19-045015_policies/up.sql
@@ -24,14 +24,12 @@ CREATE TABLE workspace_policies (
     -- Core attributes
     display_name    TEXT            NOT NULL,
     description     TEXT            DEFAULT NULL,
-    version         TEXT            NOT NULL,
 
     CONSTRAINT workspace_policies_display_name_length CHECK (length(trim(display_name)) BETWEEN 1 AND 255),
     CONSTRAINT workspace_policies_description_length CHECK (description IS NULL OR length(description) <= 4096),
-    CONSTRAINT workspace_policies_version_length CHECK (length(trim(version)) BETWEEN 1 AND 64),
 
-    -- Policy body (nvisy_schema::policy::Policy as JSON: rules, labels,
-    -- fallback, retention, applies_when predicate). Stored XChaCha20-Poly1305
+    -- Policy body (nvisy_schema::policy::PolicyDefinition as JSON: rules, labels,
+    -- fallback, retention, `when` predicate). Stored XChaCha20-Poly1305
     -- encrypted with the workspace-derived key.
     definition      BYTEA           NOT NULL,
 
@@ -76,7 +74,6 @@ COMMENT ON COLUMN workspace_policies.workspace_id IS 'Parent workspace reference
 COMMENT ON COLUMN workspace_policies.account_id IS 'Creator account reference';
 COMMENT ON COLUMN workspace_policies.display_name IS 'Human-readable policy display name (1-255 chars)';
 COMMENT ON COLUMN workspace_policies.description IS 'Policy description (up to 4096 chars)';
-COMMENT ON COLUMN workspace_policies.version IS 'Semver of the policy body';
 COMMENT ON COLUMN workspace_policies.definition IS 'Encrypted policy body (XChaCha20-Poly1305, workspace-derived key)';
 COMMENT ON COLUMN workspace_policies.metadata IS 'Metadata for filtering/display';
 COMMENT ON COLUMN workspace_policies.created_at IS 'Creation timestamp';


### PR DESCRIPTION
## Summary
- Bump runtime (nvisy-engine/policy/schema `e2fde94`, pulls elide `5f61386`), which renames the engine policy type `Policy` → `PolicyDefinition` and drops its `version` field.
- Follow the rename end-to-end (request/response DTOs, handler, pipeline_runs).
- Drop the `version` column, CHECK, and comment from the policies migration + model + schema, and remove its derivation in create/update.
- Add `PolicySummary` as the list-endpoint DTO: metadata only, no decryption. The full `Policy` (with `definition`) is still returned by the single-policy endpoint, so a page of policies costs no per-item decryption.

## Notes
- Resolves the OpenAPI `Policy2` name collision — the engine type is no longer named `Policy`, so our response `Policy` keeps its bare name. Verified live against `/api/openapi.json`: `Policy`, `PolicySummary`, `PolicyDefinition` all present, no `Policy2`, no `version` prop on either DTO.
- Migration edited in place; `schema.rs` regenerated.

## Test plan
- [x] `cargo check --all-features --workspace`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace`
- [x] `cargo test --all-features --workspace`
- [x] `cargo machete`
- [x] Live OpenAPI spec check (no `Policy2`, no `version`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)