### PR TITLE
Map missing DB constraints to 409/4xx instead of 500

### DIFF
--- a/crates/nvisy-postgres/src/types/constraint/account_api_tokens.rs
+++ b/crates/nvisy-postgres/src/types/constraint/account_api_tokens.rs
@@ -11,9 +11,9 @@ use super::ConstraintCategory;
 #[serde(into = "String", try_from = "String")]
 pub enum AccountApiTokenConstraints {
     // Token validation constraints
-    #[strum(serialize = "account_api_tokens_name_not_empty")]
+    #[strum(serialize = "account_api_tokens_display_name_not_empty")]
     NameNotEmpty,
-    #[strum(serialize = "account_api_tokens_name_length")]
+    #[strum(serialize = "account_api_tokens_display_name_length")]
     NameLength,
 
     // Token chronological constraints

--- a/crates/nvisy-postgres/src/types/constraint/accounts.rs
+++ b/crates/nvisy-postgres/src/types/constraint/accounts.rs
@@ -37,6 +37,8 @@ pub enum AccountConstraints {
     // Account uniqueness constraints
     #[strum(serialize = "accounts_username_unique_idx")]
     UsernameUnique,
+    #[strum(serialize = "accounts_email_address_unique_idx")]
+    EmailUnique,
 
     // Account chronological constraints
     #[strum(serialize = "accounts_updated_after_created")]
@@ -70,7 +72,9 @@ impl AccountConstraints {
             | AccountConstraints::LocaleFormat
             | AccountConstraints::SuspendedNotAdmin => ConstraintCategory::Validation,
 
-            AccountConstraints::UsernameUnique => ConstraintCategory::Uniqueness,
+            AccountConstraints::UsernameUnique | AccountConstraints::EmailUnique => {
+                ConstraintCategory::Uniqueness
+            }
 
             AccountConstraints::UpdatedAfterCreated
             | AccountConstraints::DeletedAfterCreated

--- a/crates/nvisy-postgres/src/types/constraint/files.rs
+++ b/crates/nvisy-postgres/src/types/constraint/files.rs
@@ -43,6 +43,8 @@ pub enum WorkspaceFileConstraints {
     // Uniqueness constraints
     #[strum(serialize = "workspace_files_workspace_id_id_key")]
     WorkspaceIdIdUnique,
+    #[strum(serialize = "workspace_files_source_object_unique_idx")]
+    SourceObjectUnique,
 
     // File chronological constraints
     #[strum(serialize = "workspace_files_updated_after_created")]
@@ -74,7 +76,8 @@ impl WorkspaceFileConstraints {
             | WorkspaceFileConstraints::MetadataSize
             | WorkspaceFileConstraints::VersionNumberMin => ConstraintCategory::Validation,
 
-            WorkspaceFileConstraints::WorkspaceIdIdUnique => ConstraintCategory::Uniqueness,
+            WorkspaceFileConstraints::WorkspaceIdIdUnique
+            | WorkspaceFileConstraints::SourceObjectUnique => ConstraintCategory::Uniqueness,
 
             WorkspaceFileConstraints::UpdatedAfterCreated
             | WorkspaceFileConstraints::DeletedAfterCreated

--- a/crates/nvisy-postgres/src/types/constraint/mod.rs
+++ b/crates/nvisy-postgres/src/types/constraint/mod.rs
@@ -316,7 +316,7 @@ mod tests {
             ))
         );
         assert_eq!(
-            ConstraintViolation::new("workspace_pipelines_name_length"),
+            ConstraintViolation::new("workspace_pipelines_display_name_length"),
             Some(ConstraintViolation::WorkspacePipeline(
                 WorkspacePipelineConstraints::NameLength
             ))

--- a/crates/nvisy-postgres/src/types/constraint/pipeline_runs.rs
+++ b/crates/nvisy-postgres/src/types/constraint/pipeline_runs.rs
@@ -18,6 +18,10 @@ pub enum WorkspacePipelineRunConstraints {
     #[strum(serialize = "workspace_pipeline_runs_idempotency_key_length")]
     IdempotencyKeyLength,
 
+    // Uniqueness constraints
+    #[strum(serialize = "workspace_pipeline_runs_idempotency_idx")]
+    IdempotencyUnique,
+
     // Chronological constraints
     #[strum(serialize = "workspace_pipeline_runs_completed_after_started")]
     CompletedAfterStarted,
@@ -37,6 +41,8 @@ impl WorkspacePipelineRunConstraints {
             | WorkspacePipelineRunConstraints::IdempotencyKeyLength => {
                 ConstraintCategory::Validation
             }
+
+            WorkspacePipelineRunConstraints::IdempotencyUnique => ConstraintCategory::Uniqueness,
 
             WorkspacePipelineRunConstraints::CompletedAfterStarted => {
                 ConstraintCategory::Chronological

--- a/crates/nvisy-postgres/src/types/constraint/pipelines.rs
+++ b/crates/nvisy-postgres/src/types/constraint/pipelines.rs
@@ -17,7 +17,7 @@ pub enum WorkspacePipelineConstraints {
     SlugFormat,
 
     // Pipeline name validation constraints
-    #[strum(serialize = "workspace_pipelines_name_length")]
+    #[strum(serialize = "workspace_pipelines_display_name_length")]
     NameLength,
 
     // Pipeline description validation constraints

--- a/crates/nvisy-postgres/src/types/constraint/workspace_connections.rs
+++ b/crates/nvisy-postgres/src/types/constraint/workspace_connections.rs
@@ -27,9 +27,9 @@ pub enum WorkspaceConnectionConstraints {
     MetadataSize,
 
     // Schedule validation constraints
-    #[strum(serialize = "workspace_connections_schedule_cron_length")]
+    #[strum(serialize = "workspace_connection_schedule_cron_length")]
     ScheduleCronLength,
-    #[strum(serialize = "workspace_connections_schedule_import_only")]
+    #[strum(serialize = "workspace_connection_schedule_import_only")]
     ScheduleImportOnly,
 
     // Uniqueness constraints

--- a/crates/nvisy-postgres/src/types/constraint/workspace_members.rs
+++ b/crates/nvisy-postgres/src/types/constraint/workspace_members.rs
@@ -10,6 +10,10 @@ use super::ConstraintCategory;
 #[derive(Serialize, Deserialize, Display, EnumIter, EnumString)]
 #[serde(into = "String", try_from = "String")]
 pub enum WorkspaceMemberConstraints {
+    // Member uniqueness constraints
+    #[strum(serialize = "workspace_members_pkey")]
+    MembershipUnique,
+
     // Member chronological constraints
     #[strum(serialize = "workspace_members_updated_after_created")]
     UpdatedAfterCreated,
@@ -24,6 +28,7 @@ impl WorkspaceMemberConstraints {
     /// Returns the category of this constraint violation.
     pub fn categorize(&self) -> ConstraintCategory {
         match self {
+            WorkspaceMemberConstraints::MembershipUnique => ConstraintCategory::Uniqueness,
             WorkspaceMemberConstraints::UpdatedAfterCreated => ConstraintCategory::Chronological,
         }
     }

--- a/crates/nvisy-postgres/src/types/constraint/workspace_policies.rs
+++ b/crates/nvisy-postgres/src/types/constraint/workspace_policies.rs
@@ -15,12 +15,10 @@ pub enum WorkspacePolicyConstraints {
     SlugLength,
     #[strum(serialize = "workspace_policies_slug_format")]
     SlugFormat,
-    #[strum(serialize = "workspace_policies_name_length")]
+    #[strum(serialize = "workspace_policies_display_name_length")]
     NameLength,
     #[strum(serialize = "workspace_policies_description_length")]
     DescriptionLength,
-    #[strum(serialize = "workspace_policies_version_length")]
-    VersionLength,
     #[strum(serialize = "workspace_policies_definition_size")]
     DefinitionSize,
     #[strum(serialize = "workspace_policies_metadata_size")]
@@ -31,6 +29,8 @@ pub enum WorkspacePolicyConstraints {
     WorkspaceIdIdUnique,
     #[strum(serialize = "workspace_policies_workspace_id_slug_key")]
     SlugUnique,
+    #[strum(serialize = "workspace_policies_display_name_unique_idx")]
+    NameUnique,
 
     // Chronological constraints
     #[strum(serialize = "workspace_policies_updated_after_created")]
@@ -52,12 +52,12 @@ impl WorkspacePolicyConstraints {
             | WorkspacePolicyConstraints::SlugFormat
             | WorkspacePolicyConstraints::NameLength
             | WorkspacePolicyConstraints::DescriptionLength
-            | WorkspacePolicyConstraints::VersionLength
             | WorkspacePolicyConstraints::DefinitionSize
             | WorkspacePolicyConstraints::MetadataSize => ConstraintCategory::Validation,
 
             WorkspacePolicyConstraints::WorkspaceIdIdUnique
-            | WorkspacePolicyConstraints::SlugUnique => ConstraintCategory::Uniqueness,
+            | WorkspacePolicyConstraints::SlugUnique
+            | WorkspacePolicyConstraints::NameUnique => ConstraintCategory::Uniqueness,
 
             WorkspacePolicyConstraints::UpdatedAfterCreated
             | WorkspacePolicyConstraints::DeletedAfterCreated => ConstraintCategory::Chronological,

--- a/crates/nvisy-postgres/src/types/constraint/workspaces.rs
+++ b/crates/nvisy-postgres/src/types/constraint/workspaces.rs
@@ -29,6 +29,8 @@ pub enum WorkspaceConstraints {
     // Workspace uniqueness constraints
     #[strum(serialize = "workspaces_slug_key")]
     SlugUnique,
+    #[strum(serialize = "workspaces_display_name_owner_unique_idx")]
+    NameUnique,
 
     // Workspace chronological constraints
     #[strum(serialize = "workspaces_updated_after_created")]
@@ -56,7 +58,9 @@ impl WorkspaceConstraints {
             | WorkspaceConstraints::MetadataSize
             | WorkspaceConstraints::SettingsSize => ConstraintCategory::Validation,
 
-            WorkspaceConstraints::SlugUnique => ConstraintCategory::Uniqueness,
+            WorkspaceConstraints::SlugUnique | WorkspaceConstraints::NameUnique => {
+                ConstraintCategory::Uniqueness
+            }
 
             WorkspaceConstraints::UpdatedAfterCreated
             | WorkspaceConstraints::DeletedAfterCreated

--- a/crates/nvisy-server/src/handler/error/pg_account.rs
+++ b/crates/nvisy-server/src/handler/error/pg_account.rs
@@ -13,6 +13,9 @@ impl From<AccountConstraints> for Error<'static> {
                 .with_message("Handle must be between 3 and 32 characters long"),
             AccountConstraints::UsernameFormat => ErrorKind::BadRequest
                 .with_message("Handle must be lowercase alphanumeric with single internal dashes"),
+            AccountConstraints::EmailUnique => {
+                ErrorKind::Conflict.with_message("An account with this email already exists")
+            }
             AccountConstraints::UsernameUnique => {
                 ErrorKind::Conflict.with_message("Handle is already taken")
             }

--- a/crates/nvisy-server/src/handler/error/pg_document.rs
+++ b/crates/nvisy-server/src/handler/error/pg_document.rs
@@ -38,6 +38,9 @@ impl From<WorkspaceFileConstraints> for Error<'static> {
             WorkspaceFileConstraints::VersionNumberMin => {
                 ErrorKind::BadRequest.with_message("Version number must be at least 1")
             }
+            WorkspaceFileConstraints::SourceObjectUnique => {
+                ErrorKind::Conflict.with_message("This source object has already been imported")
+            }
             WorkspaceFileConstraints::WorkspaceIdIdUnique => {
                 ErrorKind::Conflict.with_message("A file with this identifier already exists")
             }

--- a/crates/nvisy-server/src/handler/error/pg_pipeline.rs
+++ b/crates/nvisy-server/src/handler/error/pg_pipeline.rs
@@ -50,19 +50,21 @@ impl From<WorkspacePipelineConstraints> for Error<'static> {
 
 impl From<WorkspacePipelineRunConstraints> for Error<'static> {
     fn from(c: WorkspacePipelineRunConstraints) -> Self {
-        let error = match c {
-            WorkspacePipelineRunConstraints::AnalyzedDocumentKeyLength => {
-                ErrorKind::InternalServerError.into_error()
-            }
-            WorkspacePipelineRunConstraints::MetadataSize => ErrorKind::BadRequest
-                .with_message("Pipeline run metadata size exceeds maximum limit"),
-            WorkspacePipelineRunConstraints::IdempotencyKeyLength => {
-                ErrorKind::BadRequest.with_message("Idempotency key must be 1 to 255 characters")
-            }
-            WorkspacePipelineRunConstraints::CompletedAfterStarted => {
-                ErrorKind::InternalServerError.into_error()
-            }
-        };
+        let error =
+            match c {
+                WorkspacePipelineRunConstraints::AnalyzedDocumentKeyLength => {
+                    ErrorKind::InternalServerError.into_error()
+                }
+                WorkspacePipelineRunConstraints::MetadataSize => ErrorKind::BadRequest
+                    .with_message("Pipeline run metadata size exceeds maximum limit"),
+                WorkspacePipelineRunConstraints::IdempotencyKeyLength => ErrorKind::BadRequest
+                    .with_message("Idempotency key must be 1 to 255 characters"),
+                WorkspacePipelineRunConstraints::IdempotencyUnique => ErrorKind::Conflict
+                    .with_message("A run with this idempotency key already exists"),
+                WorkspacePipelineRunConstraints::CompletedAfterStarted => {
+                    ErrorKind::InternalServerError.into_error()
+                }
+            };
 
         error.with_resource("pipeline_run")
     }
@@ -162,8 +164,6 @@ impl From<WorkspacePolicyConstraints> for Error<'static> {
                 .with_message("Policy name must be between 1 and 255 characters"),
             WorkspacePolicyConstraints::DescriptionLength => ErrorKind::BadRequest
                 .with_message("Policy description must be at most 4096 characters"),
-            WorkspacePolicyConstraints::VersionLength => ErrorKind::BadRequest
-                .with_message("Policy version must be between 1 and 64 characters"),
             WorkspacePolicyConstraints::DefinitionSize => {
                 ErrorKind::BadRequest.with_message("Policy definition size exceeds maximum limit")
             }
@@ -177,6 +177,9 @@ impl From<WorkspacePolicyConstraints> for Error<'static> {
             ),
             WorkspacePolicyConstraints::SlugUnique => {
                 ErrorKind::Conflict.with_message("A policy with this slug already exists")
+            }
+            WorkspacePolicyConstraints::NameUnique => {
+                ErrorKind::Conflict.with_message("A policy with this name already exists")
             }
             WorkspacePolicyConstraints::WorkspaceIdIdUnique => {
                 ErrorKind::Conflict.with_message("A policy with this identifier already exists")

--- a/crates/nvisy-server/src/handler/error/pg_workspace.rs
+++ b/crates/nvisy-server/src/handler/error/pg_workspace.rs
@@ -17,6 +17,9 @@ impl From<WorkspaceConstraints> for Error<'static> {
             WorkspaceConstraints::SlugFormat => ErrorKind::BadRequest.with_message(
                 "Workspace slug must be lowercase alphanumeric with single internal dashes",
             ),
+            WorkspaceConstraints::NameUnique => {
+                ErrorKind::Conflict.with_message("A workspace with this name already exists")
+            }
             WorkspaceConstraints::SlugUnique => {
                 ErrorKind::Conflict.with_message("A workspace with this slug already exists")
             }
@@ -46,6 +49,8 @@ impl From<WorkspaceConstraints> for Error<'static> {
 impl From<WorkspaceMemberConstraints> for Error<'static> {
     fn from(c: WorkspaceMemberConstraints) -> Self {
         let error = match c {
+            WorkspaceMemberConstraints::MembershipUnique => ErrorKind::Conflict
+                .with_message("This account is already a member of the workspace"),
             WorkspaceMemberConstraints::UpdatedAfterCreated => {
                 ErrorKind::InternalServerError.into_error()
             }


### PR DESCRIPTION
## Problem

Creating a policy with a duplicate **name** (not slug) returned an internal server error (500), with nothing in the logs.

## Root cause

Unique-constraint and CHECK violations are mapped to HTTP errors by parsing the DB constraint name against per-table enums (`#[strum(serialize = "...")]`). If the constraint name has no matching enum string, the violation is unrecognized and falls through to `InternalServerError` (500) — silently.

Auditing every constraint enum against the actual migration SQL surfaced this as systemic, not policy-specific: several tables either omitted a UNIQUE index/PK or had a serialize string that didn't match the migration's constraint name.

## Fix

**Missing UNIQUE indexes / PK — now 409:**
- `workspace_policies_display_name_unique_idx` (the reported bug — duplicate policy name)
- `accounts_email_address_unique_idx` (duplicate email)
- `workspace_files_source_object_unique_idx` (re-importing the same source object)
- `workspace_pipeline_runs_idempotency_idx` (idempotency-key replay)
- `workspaces_display_name_owner_unique_idx` (duplicate workspace name)
- `workspace_members_pkey` (re-adding an existing member)

**Mismatched serialize strings — CHECK now maps to 4xx instead of falling through:**
- `account_api_tokens_{name → display_name}_{length,not_empty}`
- `workspace_connections_schedule_* → workspace_connection_schedule_*`
- `workspace_pipelines_{name → display_name}_length`

**Cleanup:** removed the dead `VersionLength` policy variant (no such column); fixed the constraint-parsing test that hardcoded the old buggy string.

Not included: `workspace_pipeline_policies_pkey` — its insert path already dedups and does delete-then-insert in a transaction, so the PK can't be violated by valid usage; a mapping would be dead code.

Each fix adds/corrects the enum variant, classifies it under `categorize()`, and adds a `Conflict` arm with a clear message. Rust's exhaustive matches guarantee no mapping is missed.

Full CI gate passes (check, clippy, fmt, doc, machete, tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)