### PR TITLE
Update runtime, drop nvisy-template, add workspace OCR policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,7 +2898,7 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 [[package]]
 name = "elide"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-codec",
@@ -2919,7 +2919,7 @@ dependencies = [
 [[package]]
 name = "elide-bento"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#a8e2eff33dfc81c53c9555d5d752285ed8d74204"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d6b0a40e14b1927444f2015dca56aed775891fcf"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2935,7 +2935,7 @@ dependencies = [
 [[package]]
 name = "elide-codec"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "elide-context"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -2969,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "elide-core"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2987,7 +2987,7 @@ dependencies = [
 [[package]]
 name = "elide-detection"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "elide-core",
  "futures",
@@ -2999,7 +2999,7 @@ dependencies = [
 [[package]]
 name = "elide-engine"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "bytes",
  "elide-codec",
@@ -3014,7 +3014,7 @@ dependencies = [
 [[package]]
 name = "elide-fake"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "elide-lingua"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -3036,7 +3036,7 @@ dependencies = [
 [[package]]
 name = "elide-llm"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -3058,7 +3058,7 @@ dependencies = [
 [[package]]
 name = "elide-ner"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "derive_builder",
@@ -3072,7 +3072,7 @@ dependencies = [
 [[package]]
 name = "elide-ocr"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -3082,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "elide-operator"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3104,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "elide-pattern"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "elide-redaction"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -3138,7 +3138,7 @@ dependencies = [
 [[package]]
 name = "elide-stt"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/elide?branch=main#e0b4ed852e627fa8b465e78d4fc02fff5c2905aa"
+source = "git+https://github.com/nvisycom/elide?branch=main#c9599770b9ccef4acc077ba45c285af57e64a5f3"
 dependencies = [
  "async-trait",
  "elide-core",
@@ -6055,7 +6055,7 @@ dependencies = [
 [[package]]
 name = "nvisy-engine"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#a8e2eff33dfc81c53c9555d5d752285ed8d74204"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d6b0a40e14b1927444f2015dca56aed775891fcf"
 dependencies = [
  "bytes",
  "elide",
@@ -6063,6 +6063,7 @@ dependencies = [
  "elide-core",
  "hipstr",
  "nvisy-schema",
+ "nvisy-template",
  "schemars 1.2.2",
  "serde",
  "uuid",
@@ -6122,7 +6123,7 @@ dependencies = [
 [[package]]
 name = "nvisy-policy"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#a8e2eff33dfc81c53c9555d5d752285ed8d74204"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d6b0a40e14b1927444f2015dca56aed775891fcf"
 dependencies = [
  "elide-core",
  "elide-operator",
@@ -6168,7 +6169,7 @@ dependencies = [
 [[package]]
 name = "nvisy-schema"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#a8e2eff33dfc81c53c9555d5d752285ed8d74204"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d6b0a40e14b1927444f2015dca56aed775891fcf"
 dependencies = [
  "bytes",
  "elide-core",
@@ -6215,7 +6216,6 @@ dependencies = [
  "nvisy-nats",
  "nvisy-object",
  "nvisy-postgres",
- "nvisy-template",
  "nvisy-webhook",
  "pin-project-lite",
  "rand 0.10.2",
@@ -6242,7 +6242,7 @@ dependencies = [
 [[package]]
 name = "nvisy-template"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#a8e2eff33dfc81c53c9555d5d752285ed8d74204"
+source = "git+https://github.com/nvisycom/runtime?branch=main#d6b0a40e14b1927444f2015dca56aed775891fcf"
 dependencies = [
  "elide-core",
  "hipstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,8 @@ documentation = "https://docs.rs/nvisy-server"
 #
 # See for more details: https://github.com/rust-lang/cargo/issues/11329
 
-# Runtime crates
-nvisy-engine = { git = "https://github.com/nvisycom/runtime", branch = "main" }
-nvisy-template = { git = "https://github.com/nvisycom/runtime", branch = "main" }
-
 # Internal crates
+nvisy-engine = { git = "https://github.com/nvisycom/runtime", branch = "main" }
 nvisy-core = { path = "./crates/nvisy-core", version = "0.1.0" }
 nvisy-nats = { path = "./crates/nvisy-nats", version = "0.1.0" }
 nvisy-inference = { path = "./crates/nvisy-inference", version = "0.1.0" }

--- a/crates/nvisy-postgres/src/types/mod.rs
+++ b/crates/nvisy-postgres/src/types/mod.rs
@@ -33,8 +33,8 @@ pub use handle::{HANDLE_MAX_LENGTH, HANDLE_MIN_LENGTH, Handle, HandleError};
 pub use pagination::{Cursor, CursorPage, CursorPagination, OffsetPage, OffsetPagination};
 pub use prefixed_id::{ConnectionId, PrefixedIdError, RunId, WebhookId};
 pub use settings::{
-    PIPELINE_RETENTION_KEY, Retention, RetentionOverride, RetentionScope, RetentionSettings,
-    WorkspaceSettings,
+    OcrPolicy, PIPELINE_RETENTION_KEY, Retention, RetentionOverride, RetentionScope,
+    RetentionSettings, WorkspaceSettings,
 };
 pub use sorting::{
     FileSortBy, FileSortField, InviteSortBy, InviteSortField, MemberSortBy, MemberSortField,

--- a/crates/nvisy-postgres/src/types/settings/mod.rs
+++ b/crates/nvisy-postgres/src/types/settings/mod.rs
@@ -7,4 +7,4 @@ mod workspace;
 pub use retention::{
     PIPELINE_RETENTION_KEY, Retention, RetentionOverride, RetentionScope, RetentionSettings,
 };
-pub use workspace::WorkspaceSettings;
+pub use workspace::{OcrPolicy, WorkspaceSettings};

--- a/crates/nvisy-postgres/src/types/settings/workspace.rs
+++ b/crates/nvisy-postgres/src/types/settings/workspace.rs
@@ -18,6 +18,26 @@ const fn default_require_approval() -> bool {
     true
 }
 
+/// How a workspace's documents are turned into images for OCR during detection.
+///
+/// A workspace-level policy over the engine's per-run OCR mode: `Auto` lets the
+/// engine decide from the text layer, `Force` always renders every page (for
+/// documents with unreliable text layers — scans, watermarks), and `Never`
+/// relies on the text layer only.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum OcrPolicy {
+    /// Extract the text layer where present and OCR only pages that lack it.
+    #[default]
+    Auto,
+    /// Always render every page to images for OCR, ignoring any text layer.
+    Force,
+    /// Rely on the text layer only; never render pages for OCR.
+    Never,
+}
+
 /// Typed workspace settings, the JSON stored in the `workspaces.settings` column.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -26,6 +46,8 @@ const fn default_require_approval() -> bool {
 pub struct WorkspaceSettings {
     /// Whether approval is required before processed files become visible.
     pub require_approval: bool,
+    /// How documents are rendered for OCR during detection.
+    pub ocr: OcrPolicy,
     /// Data-retention rules for the workspace.
     pub retention: RetentionSettings,
 }
@@ -34,6 +56,7 @@ impl Default for WorkspaceSettings {
     fn default() -> Self {
         Self {
             require_approval: default_require_approval(),
+            ocr: OcrPolicy::Auto,
             retention: RetentionSettings::default(),
         }
     }
@@ -82,6 +105,20 @@ mod tests {
     fn require_approval_survives_round_trip() {
         let settings = WorkspaceSettings {
             require_approval: false,
+            ..Default::default()
+        };
+        let value = settings.to_value().expect("serialize");
+        assert_eq!(WorkspaceSettings::from_value(&value), settings);
+    }
+
+    #[test]
+    fn ocr_policy_defaults_to_auto_and_round_trips() {
+        assert_eq!(
+            WorkspaceSettings::from_value(&json!({})).ocr,
+            OcrPolicy::Auto
+        );
+        let settings = WorkspaceSettings {
+            ocr: OcrPolicy::Force,
             ..Default::default()
         };
         let value = settings.to_value().expect("serialize");

--- a/crates/nvisy-server/Cargo.toml
+++ b/crates/nvisy-server/Cargo.toml
@@ -31,11 +31,8 @@ default = []
 cli = ["dep:clap", "dep:humantime"]
 
 [dependencies]
-# Runtime crates
-nvisy-engine = { workspace = true }
-nvisy-template = { workspace = true }
-
 # Internal crates
+nvisy-engine = { workspace = true, features = [] }
 nvisy-core = { workspace = true, features = ["schema"] }
 nvisy-nats = { workspace = true, features = [] }
 nvisy-inference = { workspace = true, features = ["schema"] }

--- a/crates/nvisy-server/src/handler/pipeline_runs.rs
+++ b/crates/nvisy-server/src/handler/pipeline_runs.rs
@@ -13,7 +13,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use bytes::Bytes;
 use nvisy_engine::policy::PolicyDefinition;
-use nvisy_engine::{Audit, Document};
+use nvisy_engine::{Audit, Document, OcrMode};
 use nvisy_nats::NatsClient;
 use nvisy_nats::object::{AuditBucket, AuditKey, FileKey, FilesBucket};
 use nvisy_postgres::model::{
@@ -25,7 +25,7 @@ use nvisy_postgres::query::{
     WorkspacePipelineRunRepository, WorkspacePolicyRepository,
 };
 use nvisy_postgres::types::{
-    FileKind, PipelineRunStatus, RetentionOverride, RetentionScope, RetentionSettings,
+    FileKind, OcrPolicy, PipelineRunStatus, RetentionOverride, RetentionScope, RetentionSettings,
     WorkspaceSettings,
 };
 use nvisy_postgres::{PgClient, PgConn};
@@ -140,9 +140,17 @@ async fn create_pipeline_run(
         );
     }
 
+    // Map the workspace's OCR policy to the engine's per-run mode. `Force` renders
+    // every page at the engine's default DPI (no workspace DPI knob).
+    let ocr_mode = match WorkspaceSettings::from_value(&workspace.settings).ocr {
+        OcrPolicy::Auto => OcrMode::Auto,
+        OcrPolicy::Force => OcrMode::force(),
+        OcrPolicy::Never => OcrMode::Never,
+    };
+
     // Merge the pipeline's intent with the deployment defaults; rejects a
     // pipeline that enables recognizers this deployment lacks.
-    let params = match engine.analyzer_params(&definition, request.scope) {
+    let params = match engine.analyzer_params(&definition, request.scope, ocr_mode) {
         Ok(params) => params,
         Err(err) => {
             fail_run(

--- a/crates/nvisy-server/src/handler/request/policies.rs
+++ b/crates/nvisy-server/src/handler/request/policies.rs
@@ -1,8 +1,8 @@
 //! Policy request types.
 
 use nvisy_engine::policy::PolicyDefinition;
+use nvisy_engine::template::PolicyTemplate;
 use nvisy_postgres::types::Handle;
-use nvisy_template::PolicyTemplate;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;

--- a/crates/nvisy-server/src/service/engine/mod.rs
+++ b/crates/nvisy-server/src/service/engine/mod.rs
@@ -11,10 +11,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use derive_more::Deref;
-use nvisy_engine::Engine;
 use nvisy_engine::plan::{
     AnalyzerParams, AnyAnnotations, DeduplicationParams, ProviderSelection, ScopeParams,
 };
+use nvisy_engine::{Engine, OcrMode};
 
 use crate::Result;
 use crate::handler::request::PipelineDefinition;
@@ -84,9 +84,9 @@ impl EngineService {
     ///
     /// Recognizers and deduplication behavior come from the pipeline; enrichment
     /// and deduplication calibration come from the server-wide defaults. Scope is
-    /// the request's own, falling back to the pipeline default. The label catalog
-    /// is not set here: the engine derives it from the run's policies at detect
-    /// time.
+    /// the request's own, falling back to the pipeline default. `ocr_mode` is the
+    /// workspace's OCR policy (forced vs. auto). The label catalog is not set
+    /// here: the engine derives it from the run's policies at detect time.
     ///
     /// Rejects a pipeline that explicitly enables NER or LLM recognizers this
     /// deployment has no lineup for, rather than silently running without them.
@@ -94,6 +94,7 @@ impl EngineService {
         &self,
         definition: &PipelineDefinition,
         request_scope: Option<ScopeParams>,
+        ocr_mode: OcrMode,
     ) -> HandlerResult<AnalyzerParams> {
         let recognizers = &definition.recognizers;
         if wants_recognizer(recognizers.ner.as_ref()) && !self.defaults.has_ner {
@@ -130,6 +131,7 @@ impl EngineService {
             enrichers: self.defaults.enrichers.clone(),
             deduplication,
             scope,
+            ocr_mode,
             annotations: AnyAnnotations::default(),
         })
     }


### PR DESCRIPTION
## Summary
- **Bump the nvisy runtime** (`nvisy-engine` + siblings) to latest `main`.
- **Drop the direct `nvisy-template` dependency.** `PolicyTemplate` is now re-exported by `nvisy-engine` (`nvisy_engine::template`), so the single import in `handler/request/policies.rs` points there instead. Removed `nvisy-template` from both the workspace and server manifests.
- **Add an `ocr` workspace setting** — a 3-variant `OcrPolicy` (`Auto` default / `Force` / `Never`) on `WorkspaceSettings`, stored in the `workspaces.settings` JSONB. At detect time it maps to the engine's new per-run `OcrMode`: `Force` renders every page at the engine's default DPI (no workspace DPI knob), `Never` uses the text layer only, `Auto` lets the engine decide. This also satisfies the engine's new required `AnalyzerParams.ocr_mode` field introduced by the bump.

## Notes
- `OcrPolicy` lives beside the other settings value types in `nvisy-postgres::types::settings`; `JsonSchema` is feature-gated like its siblings, so it flows through the workspace request/response DTOs automatically.
- Added a round-trip/default test for the new field.

## Testing
Full gate green: `cargo check`, `clippy -D warnings`, nightly `fmt --check`, `doc -D warnings`, `cargo machete`, and `cargo test --all-features --workspace` (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)