### PR TITLE
Free up slugs after soft delete; drop workspace slug auto-suffix

### DIFF
--- a/crates/nvisy-postgres/src/error.rs
+++ b/crates/nvisy-postgres/src/error.rs
@@ -115,18 +115,6 @@ impl PgError {
         Self::Unexpected(message.into())
     }
 
-    /// Returns whether this error is a violation of a slug uniqueness
-    /// constraint on any resource (workspace or workspace-scoped config).
-    ///
-    /// Matches by constraint name so a single check covers every table's slug
-    /// unique index without enumerating each constraint enum. Handle uniqueness
-    /// constraints are named `*_slug_key` (global) or `*_workspace_id_slug_key`
-    /// (per workspace).
-    pub fn is_slug_conflict(&self) -> bool {
-        self.constraint()
-            .is_some_and(|name| name.ends_with("_slug_key"))
-    }
-
     /// Returns whether this error is a "no rows returned" result, i.e. a query
     /// that expected a row found none.
     ///

--- a/crates/nvisy-postgres/src/query/workspace.rs
+++ b/crates/nvisy-postgres/src/query/workspace.rs
@@ -12,10 +12,6 @@ use crate::model::{NewWorkspace, UpdateWorkspace, Workspace};
 use crate::types::{AccountRefRow, OffsetPagination, WithAccountRef};
 use crate::{PgConnection, PgError, PgResult, schema};
 
-/// Maximum number of slug candidates tried before giving up when generating a
-/// unique workspace slug (the preferred slug plus numeric suffixes).
-const MAX_SLUG_ATTEMPTS: u32 = 100;
-
 /// Repository for workspace database operations.
 ///
 /// Handles workspace lifecycle management including creation, updates,
@@ -23,20 +19,10 @@ const MAX_SLUG_ATTEMPTS: u32 = 100;
 pub trait WorkspaceRepository {
     /// Creates a new workspace.
     ///
-    /// Inserts a new workspace record with the provided configuration.
+    /// Inserts a new workspace record with the provided configuration. A slug or
+    /// display-name collision surfaces as a unique-constraint error for the
+    /// caller to turn into a client error.
     fn create_workspace(
-        &mut self,
-        workspace: NewWorkspace,
-    ) -> impl Future<Output = PgResult<Workspace>> + Send;
-
-    /// Creates a workspace, resolving slug collisions with a numeric suffix.
-    ///
-    /// The `workspace.slug` is treated as the preferred slug. If it is already
-    /// taken, the insert is retried with `-2`, `-3`, … suffixes until one
-    /// succeeds. The retry is driven by the database's unique constraint, so it
-    /// is race-safe: a concurrent insert of the same slug loses the race and is
-    /// retried rather than silently colliding.
-    fn create_workspace_with_unique_slug(
         &mut self,
         workspace: NewWorkspace,
     ) -> impl Future<Output = PgResult<Workspace>> + Send;
@@ -102,42 +88,6 @@ impl WorkspaceRepository for PgConnection {
             .map_err(PgError::from)?;
 
         Ok(workspace)
-    }
-
-    async fn create_workspace_with_unique_slug(
-        &mut self,
-        workspace: NewWorkspace,
-    ) -> PgResult<Workspace> {
-        let preferred = workspace.slug.clone();
-
-        // Attempt the preferred slug first, then `-2`, `-3`, … on collision.
-        // Each attempt uses a fresh candidate cloned from the base record, so a
-        // failed insert never consumes the data needed for the next try. The
-        // loop is bounded; in practice the first suffix or two resolves any
-        // realistic collision.
-        for attempt in 0..MAX_SLUG_ATTEMPTS {
-            let candidate = if attempt == 0 {
-                workspace.clone()
-            } else {
-                let slug = preferred
-                    .with_numeric_suffix(attempt + 1)
-                    .ok_or_else(|| PgError::unexpected("workspace slug cannot be disambiguated"))?;
-                NewWorkspace {
-                    slug,
-                    ..workspace.clone()
-                }
-            };
-
-            match self.create_workspace(candidate).await {
-                Ok(created) => return Ok(created),
-                Err(error) if error.is_slug_conflict() => continue,
-                Err(error) => return Err(error),
-            }
-        }
-
-        Err(PgError::unexpected(
-            "exhausted workspace slug generation attempts",
-        ))
     }
 
     async fn find_workspace_by_id(&mut self, workspace_id: Uuid) -> PgResult<Option<Workspace>> {

--- a/crates/nvisy-postgres/src/types/constraint/pipelines.rs
+++ b/crates/nvisy-postgres/src/types/constraint/pipelines.rs
@@ -43,7 +43,7 @@ pub enum WorkspacePipelineConstraints {
     // Uniqueness constraints
     #[strum(serialize = "workspace_pipelines_workspace_id_id_key")]
     WorkspaceIdIdUnique,
-    #[strum(serialize = "workspace_pipelines_workspace_id_slug_key")]
+    #[strum(serialize = "workspace_pipelines_slug_unique_idx")]
     SlugUnique,
 
     // Pipeline chronological constraints

--- a/crates/nvisy-postgres/src/types/constraint/workspace_policies.rs
+++ b/crates/nvisy-postgres/src/types/constraint/workspace_policies.rs
@@ -27,7 +27,7 @@ pub enum WorkspacePolicyConstraints {
     // Uniqueness constraints
     #[strum(serialize = "workspace_policies_workspace_id_id_key")]
     WorkspaceIdIdUnique,
-    #[strum(serialize = "workspace_policies_workspace_id_slug_key")]
+    #[strum(serialize = "workspace_policies_slug_unique_idx")]
     SlugUnique,
     #[strum(serialize = "workspace_policies_display_name_unique_idx")]
     NameUnique,

--- a/crates/nvisy-postgres/src/types/constraint/workspaces.rs
+++ b/crates/nvisy-postgres/src/types/constraint/workspaces.rs
@@ -27,7 +27,7 @@ pub enum WorkspaceConstraints {
     SettingsSize,
 
     // Workspace uniqueness constraints
-    #[strum(serialize = "workspaces_slug_key")]
+    #[strum(serialize = "workspaces_slug_unique_idx")]
     SlugUnique,
     #[strum(serialize = "workspaces_display_name_owner_unique_idx")]
     NameUnique,

--- a/crates/nvisy-postgres/src/types/handle.rs
+++ b/crates/nvisy-postgres/src/types/handle.rs
@@ -69,24 +69,6 @@ impl Handle {
         Self::parse(trimmed).ok()
     }
 
-    /// Returns a variant of this handle disambiguated by a numeric suffix, e.g.
-    /// `acme` with `n = 2` becomes `acme-2`.
-    ///
-    /// The base is truncated if necessary so the suffixed handle still fits
-    /// within [`HANDLE_MAX_LENGTH`]. Used to resolve collisions during
-    /// generation. Returns `None` only if `n` is so large the suffix alone cannot
-    /// fit.
-    pub fn with_numeric_suffix(&self, n: u32) -> Option<Self> {
-        let suffix = format!("-{n}");
-        let budget = HANDLE_MAX_LENGTH.checked_sub(suffix.len())?;
-        if budget < HANDLE_MIN_LENGTH {
-            return None;
-        }
-
-        let base = truncate_on_dash(&self.0, budget);
-        Self::parse(format!("{base}{suffix}")).ok()
-    }
-
     /// Returns the handle as a string slice.
     #[inline]
     #[must_use]
@@ -249,22 +231,5 @@ mod tests {
         let handle = Handle::parse("acme-corp").unwrap();
         let string: String = handle.clone().into();
         assert_eq!(Handle::try_from(string).unwrap(), handle);
-    }
-
-    #[test]
-    fn numeric_suffix_appends_and_stays_valid() {
-        let handle = Handle::parse("acme").unwrap();
-        assert_eq!(handle.with_numeric_suffix(2).unwrap().as_str(), "acme-2");
-        assert_eq!(handle.with_numeric_suffix(17).unwrap().as_str(), "acme-17");
-    }
-
-    #[test]
-    fn numeric_suffix_truncates_long_base_to_fit() {
-        // 32-char base leaves no room for "-2" without truncation.
-        let handle = Handle::parse("a".repeat(HANDLE_MAX_LENGTH)).unwrap();
-        let suffixed = handle.with_numeric_suffix(2).unwrap();
-        assert!(suffixed.as_str().len() <= HANDLE_MAX_LENGTH);
-        assert!(suffixed.as_str().ends_with("-2"));
-        assert!(!suffixed.as_str().contains("--"));
     }
 }

--- a/crates/nvisy-server/src/handler/workspaces.rs
+++ b/crates/nvisy-server/src/handler/workspaces.rs
@@ -75,9 +75,7 @@ async fn create_workspace(
 
     let (workspace, membership) = conn
         .transaction(async |conn| {
-            let workspace = conn
-                .create_workspace_with_unique_slug(new_workspace)
-                .await?;
+            let workspace = conn.create_workspace(new_workspace).await?;
             let new_member = NewWorkspaceMember::new_owner(workspace.id, creator_id);
             let member = conn.add_workspace_member(new_member).await?;
             Ok::<(WorkspaceModel, WorkspaceMember), nvisy_postgres::PgError>((workspace, member))

--- a/migrations/2025-05-21-222840_workspaces/up.sql
+++ b/migrations/2025-05-21-222840_workspaces/up.sql
@@ -14,9 +14,10 @@ CREATE TABLE workspaces (
     CONSTRAINT workspaces_display_name_length CHECK (length(trim(display_name)) BETWEEN 2 AND 32),
     CONSTRAINT workspaces_description_length_max CHECK (length(description) <= 500),
 
-    -- Human-readable URL identity. Mirrors the WorkspaceSlug newtype: lowercase
-    -- alphanumeric with single internal dashes, 3-32 characters.
-    CONSTRAINT workspaces_slug_key UNIQUE (slug),
+    -- Human-readable URL identity, unique among live workspaces (enforced by a
+    -- partial index below so a slug frees up after soft deletion). Mirrors the
+    -- WorkspaceSlug newtype: lowercase alphanumeric with single internal dashes,
+    -- 3-32 characters.
     CONSTRAINT workspaces_slug_length CHECK (length(slug) BETWEEN 3 AND 32),
     CONSTRAINT workspaces_slug_format CHECK (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
 
@@ -46,6 +47,10 @@ CREATE TABLE workspaces (
 SELECT setup_updated_at('workspaces');
 
 -- Indexes for workspaces table
+CREATE UNIQUE INDEX workspaces_slug_unique_idx
+    ON workspaces (slug)
+    WHERE deleted_at IS NULL;
+
 CREATE UNIQUE INDEX workspaces_display_name_owner_unique_idx
     ON workspaces (lower(display_name), created_by)
     WHERE deleted_at IS NULL;

--- a/migrations/2026-01-19-045014_pipelines/up.sql
+++ b/migrations/2026-01-19-045014_pipelines/up.sql
@@ -44,10 +44,10 @@ CREATE TABLE workspace_pipelines (
     -- Composite key target for workspace-scoped foreign keys (join tables).
     CONSTRAINT workspace_pipelines_workspace_id_id_key UNIQUE (workspace_id, id),
 
-    -- URL identity, unique within the workspace: lowercase alphanumeric with
-    -- single internal dashes, 3-32 characters.
+    -- URL identity, unique within the workspace (among live pipelines; enforced
+    -- by a partial index below so a slug frees up after soft deletion): lowercase
+    -- alphanumeric with single internal dashes, 3-32 characters.
     slug            TEXT             NOT NULL,
-    CONSTRAINT workspace_pipelines_workspace_id_slug_key UNIQUE (workspace_id, slug),
     CONSTRAINT workspace_pipelines_slug_length CHECK (length(slug) BETWEEN 3 AND 32),
     CONSTRAINT workspace_pipelines_slug_format CHECK (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
 
@@ -94,6 +94,10 @@ CREATE TABLE workspace_pipelines (
 SELECT setup_updated_at('workspace_pipelines');
 
 -- Indexes
+CREATE UNIQUE INDEX workspace_pipelines_slug_unique_idx
+    ON workspace_pipelines (workspace_id, slug)
+    WHERE deleted_at IS NULL;
+
 CREATE INDEX workspace_pipelines_workspace_idx
     ON workspace_pipelines (workspace_id, created_at DESC)
     WHERE deleted_at IS NULL;

--- a/migrations/2026-01-19-045015_policies/up.sql
+++ b/migrations/2026-01-19-045015_policies/up.sql
@@ -14,10 +14,10 @@ CREATE TABLE workspace_policies (
     -- Composite key target for workspace-scoped foreign keys (join tables).
     CONSTRAINT workspace_policies_workspace_id_id_key UNIQUE (workspace_id, id),
 
-    -- URL identity, unique within the workspace: lowercase alphanumeric with
-    -- single internal dashes, 3-32 characters.
+    -- URL identity, unique within the workspace (among live policies; enforced by
+    -- a partial index below so a slug frees up after soft deletion): lowercase
+    -- alphanumeric with single internal dashes, 3-32 characters.
     slug            TEXT            NOT NULL,
-    CONSTRAINT workspace_policies_workspace_id_slug_key UNIQUE (workspace_id, slug),
     CONSTRAINT workspace_policies_slug_length CHECK (length(slug) BETWEEN 3 AND 32),
     CONSTRAINT workspace_policies_slug_format CHECK (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
 
@@ -59,6 +59,10 @@ CREATE INDEX workspace_policies_workspace_idx
 
 CREATE INDEX workspace_policies_account_idx
     ON workspace_policies (account_id, created_at DESC)
+    WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX workspace_policies_slug_unique_idx
+    ON workspace_policies (workspace_id, slug)
     WHERE deleted_at IS NULL;
 
 CREATE UNIQUE INDEX workspace_policies_display_name_unique_idx


### PR DESCRIPTION
## Problem
You couldn't create a new workspace/pipeline/policy reusing the slug (or name) of a previously **deleted** one — and creating a workspace with a name that derives to an existing slug returned a **500** instead of a clean error.

Two distinct bugs:
1. **Slug uniqueness ignored soft deletes.** Slug was enforced by a plain `UNIQUE` table constraint, which counts *all* rows including soft-deleted ones. Delete is a soft delete (`deleted_at`), so a tombstoned row kept occupying the slug forever. (`display_name`, enforced by a partial index `WHERE deleted_at IS NULL`, was already reuse-able — the inconsistency was the tell.)
2. **Transaction-poisoning 500.** `create_workspace` derives a slug from the name and ran an auto-suffix retry loop (`acme` → `acme-2` …) *inside* the create transaction. A first-attempt slug collision aborts the Postgres transaction, so every retry failed with `current transaction is aborted` → generic 500.

## Fix
- Convert the slug `UNIQUE` constraint → a **partial unique index** (`WHERE deleted_at IS NULL`) on `workspaces`, `workspace_pipelines`, and `workspace_policies`, matching the existing `display_name` indexes. A slug frees up as soon as its row is soft-deleted.
- Update the `SlugUnique` constraint-name mappings to the new index names, so a live duplicate still maps to a friendly **409 Conflict** (not a 500).
- **Remove the workspace slug auto-suffix system** (`create_workspace_with_unique_slug`, `Error::is_slug_conflict`, `Handle::with_numeric_suffix`). A duplicate slug/name now returns a clean client error, consistent with how pipelines and policies already behave — and it eliminates the transaction-poisoning path.

## Verified
Reproduced end-to-end against Postgres: create → live-duplicate raises a clean `unique_violation` on `*_slug_unique_idx` (→ 409) → soft-delete → recreate with the same slug now **succeeds**.

Full gate green: `cargo check`, `clippy -D warnings`, nightly `fmt --check`, `doc -D warnings`, `cargo machete`, `cargo test --all-features --workspace` (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)