### PR TITLE
Bump runtime: drop custom pattern recognizers from pipeline definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,7 +2919,7 @@ dependencies = [
 [[package]]
 name = "elide-bento"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#72322f3a5335216a81fd1586a09a5b9cb3ea826c"
+source = "git+https://github.com/nvisycom/runtime?branch=main#2b40293abcb71cc3765be6cd6d62dfb46969e835"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2927,6 +2927,7 @@ dependencies = [
  "elide-core",
  "elide-ner",
  "elide-ocr",
+ "elide-stt",
  "hipstr",
  "serde",
  "thiserror",
@@ -6055,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "nvisy-engine"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#72322f3a5335216a81fd1586a09a5b9cb3ea826c"
+source = "git+https://github.com/nvisycom/runtime?branch=main#2b40293abcb71cc3765be6cd6d62dfb46969e835"
 dependencies = [
  "bytes",
  "elide",
@@ -6123,7 +6124,7 @@ dependencies = [
 [[package]]
 name = "nvisy-policy"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#72322f3a5335216a81fd1586a09a5b9cb3ea826c"
+source = "git+https://github.com/nvisycom/runtime?branch=main#2b40293abcb71cc3765be6cd6d62dfb46969e835"
 dependencies = [
  "elide-core",
  "elide-operator",
@@ -6169,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "nvisy-schema"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#72322f3a5335216a81fd1586a09a5b9cb3ea826c"
+source = "git+https://github.com/nvisycom/runtime?branch=main#2b40293abcb71cc3765be6cd6d62dfb46969e835"
 dependencies = [
  "bytes",
  "elide-core",
@@ -6242,7 +6243,7 @@ dependencies = [
 [[package]]
 name = "nvisy-template"
 version = "0.1.0"
-source = "git+https://github.com/nvisycom/runtime?branch=main#72322f3a5335216a81fd1586a09a5b9cb3ea826c"
+source = "git+https://github.com/nvisycom/runtime?branch=main#2b40293abcb71cc3765be6cd6d62dfb46969e835"
 dependencies = [
  "elide-core",
  "hipstr",
@@ -6959,7 +6960,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8546,7 +8547,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -8558,7 +8559,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/crates/nvisy-server/src/handler/request/pipelines.rs
+++ b/crates/nvisy-server/src/handler/request/pipelines.rs
@@ -4,7 +4,7 @@
 //! creation, updates, and filtering. All request types support JSON serialization
 //! and validation.
 
-use nvisy_engine::plan::{RecognizerParams, ScopeParams};
+use nvisy_engine::plan::ScopeParams;
 use nvisy_postgres::model::{NewWorkspacePipeline, UpdateWorkspacePipeline as UpdatePipelineModel};
 use nvisy_postgres::types::{Handle, PipelineStatus, RetentionOverride};
 use schemars::JsonSchema;
@@ -14,20 +14,17 @@ use validator::Validate;
 
 /// A pipeline's detection + governance intent.
 ///
-/// Holds what a pipeline author decides — any custom recognizer rules, the
-/// default scope, and the policies to apply. Infrastructure config (NER/LLM
-/// lineups, enrichment backends, deduplication) is server-wide and lives in the
-/// engine config, not here. Stored as JSON in the pipeline's `definition` column
-/// but validated against this schema at the API boundary.
+/// Holds what a pipeline author decides — the default scope and the policies to
+/// apply. Recognition is entirely server-wide: the built-in pattern set plus the
+/// deployment's NER/LLM lineups and enrichment backends live in the engine
+/// config, not here. Stored as JSON in the pipeline's `definition` column but
+/// validated against this schema at the API boundary.
 ///
 /// The label catalog is not part of this: the policies own the label vocabulary,
 /// and the engine derives the detection catalog from them at run time.
 ///
 /// The split:
 ///
-/// - `recognizers` — caller-inlined custom pattern rules and dictionaries,
-///   folded into an `AnalyzerParams` alongside the engine's built-in and
-///   deployment recognizers.
 /// - `default_scope` — optional pipeline-wide scope a document may override.
 /// - `policy_slugs` — references to the workspace's policies, resolved at run
 ///   time.
@@ -35,11 +32,6 @@ use validator::Validate;
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, Validate)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PipelineDefinition {
-    /// Caller-inlined custom pattern rules and dictionaries, added to the
-    /// built-in recognizers. The deployment's NER/LLM lineups always run and
-    /// are not selectable here.
-    #[serde(default)]
-    pub recognizers: RecognizerParams,
     /// Optional pipeline-wide scope (languages, jurisdictions, document labels).
     ///
     /// A document's own scope overrides this at detect time; absent here means

--- a/crates/nvisy-server/src/service/engine/mod.rs
+++ b/crates/nvisy-server/src/service/engine/mod.rs
@@ -78,12 +78,12 @@ impl EngineService {
 
     /// Builds the [`AnalyzerParams`] for one detect run from a pipeline's intent.
     ///
-    /// Recognizers carry the pipeline's caller-inlined custom rules and
-    /// dictionaries (the built-in pattern set and the deployment's NER/LLM
-    /// lineups always run). Scope is the request's own, falling back to the
-    /// pipeline default. `ocr_mode` is the workspace's OCR policy (forced vs.
-    /// auto). Deduplication and calibration are engine-owned defaults; the label
-    /// catalog is derived from the run's policies at detect time.
+    /// Recognition is entirely engine-owned (the built-in pattern set plus the
+    /// deployment's NER/LLM lineups always run). Scope is the request's own,
+    /// falling back to the pipeline default. `ocr_mode` is the workspace's OCR
+    /// policy (forced vs. auto). Deduplication and calibration are engine-owned
+    /// defaults; the label catalog is derived from the run's policies at detect
+    /// time.
     pub fn analyzer_params(
         &self,
         definition: &PipelineDefinition,
@@ -95,7 +95,6 @@ impl EngineService {
             .unwrap_or_default();
 
         AnalyzerParams {
-            recognizers: definition.recognizers.clone(),
             scope,
             ocr_mode,
             annotations: AnyAnnotations::default(),


### PR DESCRIPTION
Updates the engine to the latest runtime (#388: *Drop custom patterns, flatten analyzer/, add BentoStt*).

`AnalyzerParams` no longer carries a `recognizers` field and `RecognizerParams` is gone from `nvisy_schema::plan`, so recognition is now entirely engine-owned — the built-in pattern set plus the deployment's NER/LLM lineups.

## Changes
- `Cargo.lock`: relock `nvisy-engine`/`nvisy-schema` → `2b40293a`.
- `handler/request/pipelines.rs`: drop the `recognizers` field (caller-inlined custom pattern rules + dictionaries) from `PipelineDefinition`; a definition now carries only `default_scope` and `policy_slugs`.
- `service/engine/mod.rs`: `analyzer_params` no longer sets `recognizers` on `AnalyzerParams`.

No server-side wiring needed for BentoStt — the existing `[enrichers.stt]` → `SttBackend::Bento` mapping already covers it.

Full CI gate green (check, fmt, clippy, tests, doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)