### PR TITLE
Add creator + workspace slug to PipelineSummary

### DIFF
--- a/crates/nvisy-server/src/handler/pipelines.rs
+++ b/crates/nvisy-server/src/handler/pipelines.rs
@@ -151,7 +151,9 @@ async fn list_pipelines(
         )
         .await?;
 
-    let response = Page::from_cursor_page(page, |wc| PipelineSummary::from_model(wc.item));
+    let response = Page::from_cursor_page(page, |wc| {
+        PipelineSummary::from_model(wc.item, workspace.slug.clone(), wc.account.into())
+    });
 
     tracing::debug!(
         target: TRACING_TARGET,

--- a/crates/nvisy-server/src/handler/response/pipelines.rs
+++ b/crates/nvisy-server/src/handler/response/pipelines.rs
@@ -77,6 +77,10 @@ pub type PipelinesPage = Page<Pipeline>;
 pub struct PipelineSummary {
     /// URL slug of the pipeline, unique within its workspace.
     pub slug: Handle,
+    /// Handle of the workspace this pipeline belongs to.
+    pub workspace_slug: Handle,
+    /// Account that created this pipeline.
+    pub created_by: AccountRef,
     /// Pipeline display name.
     pub display_name: String,
     /// Pipeline description.
@@ -91,10 +95,17 @@ pub struct PipelineSummary {
 }
 
 impl PipelineSummary {
-    /// Creates a new instance of [`PipelineSummary`] from the database model.
-    pub fn from_model(pipeline: model::WorkspacePipeline) -> Self {
+    /// Creates a new instance of [`PipelineSummary`] from the database model and
+    /// its creator.
+    pub fn from_model(
+        pipeline: model::WorkspacePipeline,
+        workspace_slug: Handle,
+        created_by: AccountRef,
+    ) -> Self {
         Self {
             slug: pipeline.slug,
+            workspace_slug,
+            created_by,
             display_name: pipeline.display_name,
             description: pipeline.description,
             status: pipeline.status,


### PR DESCRIPTION
`PipelineSummary` (the pipeline list response) omitted the creator that `PolicySummary` carries. The list query already joins it (`WithAccountRef`), but the response closure only used `wc.item` and discarded `wc.account`.

## Changes
- `PipelineSummary` gains `created_by: AccountRef` and `workspace_slug: Handle`, for parity with `PolicySummary`.
- `PipelineSummary::from_model(pipeline, workspace_slug, created_by)`.
- The `list_pipelines` closure passes the real creator (`wc.account`) instead of dropping it.

No behavior change beyond the added fields; the data was already fetched. The full `Pipeline`, `get`, and `update` responses already resolved the true creator via `found.account`, so this brings the list summary in line.

Full CI gate green (check, fmt, clippy, tests, doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)