### PR TITLE
Block running non-enabled pipelines

### DIFF
--- a/crates/nvisy-server/src/handler/pipeline_runs.rs
+++ b/crates/nvisy-server/src/handler/pipeline_runs.rs
@@ -72,6 +72,14 @@ async fn create_pipeline_run(
 
     let pipeline = find_pipeline(&mut conn, workspace.id, &path_params.pipeline_slug).await?;
 
+    // Only an enabled pipeline runs: a draft (still being configured) or a
+    // disabled (paused) pipeline is rejected.
+    if !pipeline.status.is_enabled() {
+        return Err(ErrorKind::Conflict
+            .with_message("Pipeline is not enabled")
+            .with_resource("pipeline"));
+    }
+
     // Idempotent replay: a repeated key returns the run created the first time,
     // attributed to whoever originally triggered it (not the current caller).
     if let Some(key) = &idempotency_key


### PR DESCRIPTION
`create_pipeline_run` accepted a run request for any pipeline regardless of its lifecycle status — a `Draft` (still being configured) or `Disabled` (paused) pipeline would run anyway. `PipelineStatus` existed but nothing gated on it.

Gate the run: reject with **409 Conflict** ("Pipeline is not enabled") unless `pipeline.status.is_enabled()`. Only an `Enabled` pipeline runs.

Full CI gate green (check, fmt, clippy, tests, doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)