### PR TITLE
Async pipeline detection: 202 + SSE, with lease-claimed worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,10 @@ clear-migrations: ## Reverts all database migrations.
 	@$(call log,Reverting all migrations...)
 	@while DATABASE_URL=$(POSTGRES_URL) diesel migration list | grep -q "\\[X\\]"; do \
 		$(call log,Reverting migration...); \
-		DATABASE_URL=$(POSTGRES_URL) diesel migration revert; \
+		if ! DATABASE_URL=$(POSTGRES_URL) diesel migration revert; then \
+			$(call log,Revert failed; aborting to avoid an infinite loop.); \
+			exit 1; \
+		fi; \
 	done
 	@$(call log,All migrations reverted successfully.)
 

--- a/crates/nvisy-cli/src/main.rs
+++ b/crates/nvisy-cli/src/main.rs
@@ -72,6 +72,13 @@ async fn run() -> anyhow::Result<()> {
         let _ = retention_worker.run(retention_cancel).await;
     });
 
+    // Spawn pipeline detection worker (runs each run's analyze off the request thread)
+    let detection_worker = state.detection_worker();
+    let detection_cancel = cancel.clone();
+    let detection_handle = tokio::spawn(async move {
+        let _ = detection_worker.run(detection_cancel).await;
+    });
+
     // Run the HTTP server
     let server_result = server::serve(router, cli.server).await;
 
@@ -98,6 +105,13 @@ async fn run() -> anyhow::Result<()> {
             target: TRACING_TARGET_SHUTDOWN,
             error = %err,
             "Retention worker task panicked"
+        );
+    }
+    if let Err(err) = detection_handle.await {
+        tracing::error!(
+            target: TRACING_TARGET_SHUTDOWN,
+            error = %err,
+            "Detection worker task panicked"
         );
     }
 

--- a/crates/nvisy-nats/src/client/nats_client.rs
+++ b/crates/nvisy-nats/src/client/nats_client.rs
@@ -46,7 +46,7 @@ use crate::object::{
     AuditBucket, AvatarsBucket, FilesBucket, ObjectBucket, ObjectStore, ThumbnailsBucket,
     WorkspaceAvatarsBucket,
 };
-use crate::stream::{EventPublisher, EventStream, EventSubscriber, WebhookStream};
+use crate::stream::{BroadcastStream, EventPublisher, EventStream, EventSubscriber, WebhookStream};
 use crate::{Error, Result, TRACING_TARGET_CLIENT, TRACING_TARGET_CONNECTION};
 
 /// NATS client wrapper with connection management.
@@ -334,15 +334,10 @@ impl NatsClient {
     /// The stream ends when the subscription is dropped. Messages that fail to
     /// deserialize are skipped rather than ending the stream.
     #[tracing::instrument(skip(self), target = TRACING_TARGET_CLIENT)]
-    pub async fn subscribe_broadcast<T>(
-        &self,
-        subject: String,
-    ) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = T> + Send>>>
+    pub async fn subscribe_broadcast<T>(&self, subject: String) -> Result<BroadcastStream<T>>
     where
         T: DeserializeOwned + Send + 'static,
     {
-        use futures::StreamExt;
-
         let subscriber = self
             .inner
             .client
@@ -350,9 +345,6 @@ impl NatsClient {
             .await
             .map_err(|e| Error::Connection(Box::new(e)))?;
 
-        let stream = subscriber
-            .filter_map(|message| async move { serde_json::from_slice::<T>(&message.payload).ok() })
-            .boxed();
-        Ok(stream)
+        Ok(BroadcastStream::new(subscriber))
     }
 }

--- a/crates/nvisy-nats/src/client/nats_client.rs
+++ b/crates/nvisy-nats/src/client/nats_client.rs
@@ -302,3 +302,56 @@ impl NatsClient {
         self.event_subscriber().await
     }
 }
+
+// Core NATS pub/sub (non-JetStream broadcast).
+//
+// Unlike the JetStream helpers above, these use plain NATS subjects: fire-and-
+// forget, no persistence, and every subscriber to a subject receives every
+// message (fan-out). Suited to ephemeral fan-out where the durable source of
+// truth lives elsewhere (e.g. streaming run-status changes to any number of
+// watching SSE connections; the run row in Postgres is authoritative).
+impl NatsClient {
+    /// Publishes a JSON-serialized message to a core NATS subject.
+    ///
+    /// Best-effort: delivered to whichever subscribers are connected now, with no
+    /// persistence or acknowledgement.
+    #[tracing::instrument(skip(self, message), target = TRACING_TARGET_CLIENT)]
+    pub async fn publish_broadcast<T>(&self, subject: String, message: &T) -> Result<()>
+    where
+        T: Serialize,
+    {
+        let payload = serde_json::to_vec(message)?;
+        self.inner
+            .client
+            .publish(subject, payload.into())
+            .await
+            .map_err(|e| Error::Connection(Box::new(e)))?;
+        Ok(())
+    }
+
+    /// Subscribes to a core NATS subject, yielding each deserialized message.
+    ///
+    /// The stream ends when the subscription is dropped. Messages that fail to
+    /// deserialize are skipped rather than ending the stream.
+    #[tracing::instrument(skip(self), target = TRACING_TARGET_CLIENT)]
+    pub async fn subscribe_broadcast<T>(
+        &self,
+        subject: String,
+    ) -> Result<impl futures::Stream<Item = T> + Send>
+    where
+        T: DeserializeOwned + Send + 'static,
+    {
+        use futures::StreamExt;
+
+        let subscriber = self
+            .inner
+            .client
+            .subscribe(subject)
+            .await
+            .map_err(|e| Error::Connection(Box::new(e)))?;
+
+        Ok(subscriber.filter_map(|message| async move {
+            serde_json::from_slice::<T>(&message.payload).ok()
+        }))
+    }
+}

--- a/crates/nvisy-nats/src/client/nats_client.rs
+++ b/crates/nvisy-nats/src/client/nats_client.rs
@@ -337,7 +337,7 @@ impl NatsClient {
     pub async fn subscribe_broadcast<T>(
         &self,
         subject: String,
-    ) -> Result<impl futures::Stream<Item = T> + Send>
+    ) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = T> + Send>>>
     where
         T: DeserializeOwned + Send + 'static,
     {
@@ -350,8 +350,9 @@ impl NatsClient {
             .await
             .map_err(|e| Error::Connection(Box::new(e)))?;
 
-        Ok(subscriber.filter_map(|message| async move {
-            serde_json::from_slice::<T>(&message.payload).ok()
-        }))
+        let stream = subscriber
+            .filter_map(|message| async move { serde_json::from_slice::<T>(&message.payload).ok() })
+            .boxed();
+        Ok(stream)
     }
 }

--- a/crates/nvisy-nats/src/stream/broadcast_stream.rs
+++ b/crates/nvisy-nats/src/stream/broadcast_stream.rs
@@ -1,0 +1,53 @@
+//! Typed stream over a core-NATS (non-JetStream) subscription.
+
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use async_nats::Subscriber;
+use futures::Stream;
+use serde::de::DeserializeOwned;
+
+/// A typed stream of messages from a core-NATS subject subscription.
+///
+/// Wraps a raw [`Subscriber`] and yields each payload deserialized into `T`.
+/// Messages that fail to deserialize are skipped rather than ending the stream.
+/// The stream ends when the underlying subscription is dropped or unsubscribed.
+#[must_use = "streams do nothing unless polled"]
+pub struct BroadcastStream<T> {
+    subscriber: Subscriber,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<T> BroadcastStream<T> {
+    /// Wraps a raw subscriber into a typed broadcast stream.
+    pub(crate) fn new(subscriber: Subscriber) -> Self {
+        Self {
+            subscriber,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Stream for BroadcastStream<T>
+where
+    T: DeserializeOwned,
+{
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match Pin::new(&mut self.subscriber).poll_next(cx) {
+                Poll::Ready(Some(message)) => {
+                    // Skip messages that fail to deserialize; a malformed
+                    // broadcast should not tear down the subscription.
+                    if let Ok(value) = serde_json::from_slice::<T>(&message.payload) {
+                        return Poll::Ready(Some(value));
+                    }
+                }
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}

--- a/crates/nvisy-nats/src/stream/event_stream.rs
+++ b/crates/nvisy-nats/src/stream/event_stream.rs
@@ -69,6 +69,26 @@ impl EventStream for ConnectionSyncStream {
     const SUBJECT: &'static str = "connection.sync.jobs";
 }
 
+/// Work queue for pipeline detection jobs.
+///
+/// A pipeline run is created synchronously, then its detection (analyze) is
+/// enqueued here and handled by a background worker. A single shared durable
+/// consumer delivers each job to one instance at a time (at-least-once); the
+/// worker is idempotent on the run so a redelivery is safe. Messages expire
+/// after 1 hour so a backlog cannot pile up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct DetectionStream;
+
+impl EventStream for DetectionStream {
+    // Detection can be slow (LLM/OCR); allow ack time to exceed the longest
+    // expected analyze so a slow-but-healthy job is not redelivered mid-run.
+    const ACK_WAIT: Option<Duration> = Some(Duration::from_secs(15 * 60));
+    const CONSUMER_NAME: &'static str = "detection-worker";
+    const MAX_AGE: Option<Duration> = Some(Duration::from_secs(60 * 60));
+    const NAME: &'static str = "DETECTIONS";
+    const SUBJECT: &'static str = "pipeline.detection.jobs";
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/nvisy-nats/src/stream/mod.rs
+++ b/crates/nvisy-nats/src/stream/mod.rs
@@ -3,12 +3,14 @@
 //! This module provides type-safe streaming capabilities: generic event
 //! publishing and subscribing over a stream configured via [`EventStream`].
 
+mod broadcast_stream;
 mod event_pub;
 mod event_stream;
 mod event_sub;
 mod stream_pub;
 mod stream_sub;
 
+pub use broadcast_stream::BroadcastStream;
 pub use event_pub::EventPublisher;
 pub use event_stream::{ConnectionSyncStream, DetectionStream, EventStream, WebhookStream};
 pub use event_sub::EventSubscriber;

--- a/crates/nvisy-nats/src/stream/mod.rs
+++ b/crates/nvisy-nats/src/stream/mod.rs
@@ -10,7 +10,7 @@ mod stream_pub;
 mod stream_sub;
 
 pub use event_pub::EventPublisher;
-pub use event_stream::{ConnectionSyncStream, EventStream, WebhookStream};
+pub use event_stream::{ConnectionSyncStream, DetectionStream, EventStream, WebhookStream};
 pub use event_sub::EventSubscriber;
 pub use stream_pub::StreamPublisher;
 pub use stream_sub::{StreamSubscriber, TypedBatchStream, TypedMessage, TypedMessageStream};

--- a/crates/nvisy-nats/src/stream/stream_sub.rs
+++ b/crates/nvisy-nats/src/stream/stream_sub.rs
@@ -344,27 +344,49 @@ where
         }
         let messages = self.messages.as_mut().expect("message stream initialized");
 
-        match messages.next().await {
-            Some(Ok(message)) => {
-                let payload: T = serde_json::from_slice(&message.payload)?;
-
-                tracing::debug!(
-                    target: TRACING_TARGET_STREAM,
-                    subject = %message.subject,
-                    "Received typed message"
-                );
-
-                Ok(Some(TypedMessage { payload, message }))
+        // Skip over poison messages (payloads that cannot be deserialized) by
+        // terminating them, so a single bad message does not stall the consumer.
+        loop {
+            match messages.next().await {
+                Some(Ok(message)) => match serde_json::from_slice::<T>(&message.payload) {
+                    Ok(payload) => {
+                        tracing::debug!(
+                            target: TRACING_TARGET_STREAM,
+                            subject = %message.subject,
+                            "Received typed message"
+                        );
+                        return Ok(Some(TypedMessage { payload, message }));
+                    }
+                    Err(err) => {
+                        // A payload that cannot be deserialized will never succeed,
+                        // so terminate it (drop permanently) rather than leaving it
+                        // un-acked to be redelivered until the stream ages it out.
+                        tracing::error!(
+                            target: TRACING_TARGET_STREAM,
+                            subject = %message.subject,
+                            error = %err,
+                            "Terminating undeserializable message"
+                        );
+                        if let Err(ack_err) = message.ack_with(jetstream::AckKind::Term).await {
+                            tracing::warn!(
+                                target: TRACING_TARGET_STREAM,
+                                error = %ack_err,
+                                "Failed to terminate undeserializable message"
+                            );
+                        }
+                        // Continue to the next message.
+                    }
+                },
+                Some(Err(e)) => {
+                    tracing::warn!(
+                        target: TRACING_TARGET_STREAM,
+                        error = %e,
+                        "Error receiving message"
+                    );
+                    return Err(Error::operation("message_receive", e.to_string()));
+                }
+                None => return Ok(None),
             }
-            Some(Err(e)) => {
-                tracing::warn!(
-                    target: TRACING_TARGET_STREAM,
-                    error = %e,
-                    "Error receiving message"
-                );
-                Err(Error::operation("message_receive", e.to_string()))
-            }
-            None => Ok(None),
         }
     }
 }

--- a/crates/nvisy-postgres/src/model/workspace_pipeline_run.rs
+++ b/crates/nvisy-postgres/src/model/workspace_pipeline_run.rs
@@ -39,6 +39,11 @@ pub struct WorkspacePipelineRun {
     pub idempotency_key: Option<String>,
     /// Non-encrypted metadata for filtering/display.
     pub metadata: serde_json::Value,
+    /// When a worker last claimed this run for detection. Acts as a lease: a
+    /// redelivered job whose claim is still fresh is skipped, while a stale
+    /// claim (a worker that died mid-analysis) can be re-claimed. `None` until
+    /// first claimed.
+    pub claimed_at: Option<Timestamp>,
     /// When the run started.
     pub started_at: Timestamp,
     /// When the run completed.
@@ -83,14 +88,21 @@ pub struct UpdateWorkspacePipelineRun {
     pub output_file_id: Option<Option<Uuid>>,
     /// Non-encrypted metadata for filtering/display.
     pub metadata: Option<serde_json::Value>,
+    /// When a worker last claimed this run for detection (lease timestamp).
+    pub claimed_at: Option<Option<Timestamp>>,
     /// When the run completed.
     pub completed_at: Option<Option<Timestamp>>,
 }
 
 impl WorkspacePipelineRun {
-    /// Returns whether detection is in progress.
-    pub fn is_running(&self) -> bool {
-        self.status.is_running()
+    /// Returns whether the run is enqueued and not yet picked up by a worker.
+    pub fn is_queued(&self) -> bool {
+        self.status.is_queued()
+    }
+
+    /// Returns whether a worker is actively analyzing the document.
+    pub fn is_analyzing(&self) -> bool {
+        self.status.is_analyzing()
     }
 
     /// Returns whether detection is done and the run awaits verification.

--- a/crates/nvisy-postgres/src/query/workspace_file.rs
+++ b/crates/nvisy-postgres/src/query/workspace_file.rs
@@ -337,7 +337,11 @@ impl WorkspaceFileRepository for PgConnection {
         let active_run_holds_file = exists(
             workspace_pipeline_runs::table.filter(
                 runs::status
-                    .eq_any([PipelineRunStatus::Running, PipelineRunStatus::Analyzed])
+                    .eq_any([
+                        PipelineRunStatus::Queued,
+                        PipelineRunStatus::Analyzing,
+                        PipelineRunStatus::Analyzed,
+                    ])
                     .and(
                         runs::input_file_id
                             .eq(workspace_files::id)

--- a/crates/nvisy-postgres/src/query/workspace_pipeline_run.rs
+++ b/crates/nvisy-postgres/src/query/workspace_pipeline_run.rs
@@ -68,6 +68,23 @@ pub trait WorkspacePipelineRunRepository {
         status_filter: Option<PipelineRunStatus>,
     ) -> impl Future<Output = PgResult<CursorPage<(WithAccountRef<WorkspacePipelineRun>, Handle)>>> + Send;
 
+    /// Atomically claims a run for detection, transitioning it to `Analyzing`.
+    ///
+    /// Succeeds (returning the claimed run) only when the run is still `Queued`,
+    /// or is `Analyzing` but its previous claim has gone stale (`claimed_at`
+    /// older than `stale_before` — a worker that died mid-analysis). A run
+    /// already being analyzed under a fresh claim, or past the detect phase,
+    /// yields `None` so a redelivered job skips it instead of analyzing twice.
+    ///
+    /// The claim stamps `claimed_at = now()`, so the lease renews on each
+    /// (re)claim. Callers pass `stale_before = now - lease` computed against the
+    /// same clock the DB uses closely enough for a lease measured in minutes.
+    fn claim_run_for_detection(
+        &mut self,
+        run_id: Uuid,
+        stale_before: jiff::Timestamp,
+    ) -> impl Future<Output = PgResult<Option<WorkspacePipelineRun>>> + Send;
+
     /// Updates a workspace pipeline run with new data.
     fn update_workspace_pipeline_run(
         &mut self,
@@ -331,6 +348,41 @@ impl WorkspacePipelineRunRepository for PgConnection {
                 (wc.item.started_at.into(), wc.item.id)
             },
         ))
+    }
+
+    async fn claim_run_for_detection(
+        &mut self,
+        run_id: Uuid,
+        stale_before: jiff::Timestamp,
+    ) -> PgResult<Option<WorkspacePipelineRun>> {
+        use schema::workspace_pipeline_runs::{self, dsl};
+
+        let stale_before = jiff_diesel::Timestamp::from(stale_before);
+
+        // Claim only if still queued, or analyzing under a claim that has gone
+        // stale (a dead worker). The WHERE clause makes the transition atomic:
+        // two concurrent deliveries race on the same row and exactly one flips
+        // it to `analyzing`; the loser matches no row and gets `None`.
+        let claimed = diesel::update(
+            workspace_pipeline_runs::table
+                .filter(dsl::id.eq(run_id))
+                .filter(
+                    dsl::status.eq(PipelineRunStatus::Queued).or(dsl::status
+                        .eq(PipelineRunStatus::Analyzing)
+                        .and(dsl::claimed_at.lt(stale_before))),
+                ),
+        )
+        .set((
+            dsl::status.eq(PipelineRunStatus::Analyzing),
+            dsl::claimed_at.eq(diesel::dsl::now),
+        ))
+        .returning(WorkspacePipelineRun::as_returning())
+        .get_result(self)
+        .await
+        .optional()
+        .map_err(PgError::from)?;
+
+        Ok(claimed)
     }
 
     async fn update_workspace_pipeline_run(

--- a/crates/nvisy-postgres/src/schema.rs
+++ b/crates/nvisy-postgres/src/schema.rs
@@ -293,6 +293,7 @@ diesel::table! {
         status -> PipelineRunStatus,
         idempotency_key -> Nullable<Text>,
         metadata -> Jsonb,
+        claimed_at -> Nullable<Timestamptz>,
         started_at -> Timestamptz,
         completed_at -> Nullable<Timestamptz>,
     }

--- a/crates/nvisy-postgres/src/types/enums/pipeline_run_status.rs
+++ b/crates/nvisy-postgres/src/types/enums/pipeline_run_status.rs
@@ -10,16 +10,25 @@ use strum::{Display, EnumIter, EnumString};
 ///
 /// This enumeration corresponds to the `PIPELINE_RUN_STATUS` PostgreSQL enum and is used
 /// to track the current state of a pipeline execution.
+///
+/// The detect phase has two states: `Queued` (the run is enqueued but no worker
+/// has begun) and `Analyzing` (a worker is actively analyzing). They settle into
+/// `Analyzed` (detection done, awaiting review), then `Completed` after redaction.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[derive(Serialize, Deserialize, DbEnum, Display, EnumIter, EnumString)]
 #[ExistingTypePath = "crate::schema::sql_types::PipelineRunStatus"]
 pub enum PipelineRunStatus {
-    /// Detection in progress
-    #[db_rename = "running"]
-    #[serde(rename = "running")]
+    /// Enqueued for detection; no worker has picked it up yet
+    #[db_rename = "queued"]
+    #[serde(rename = "queued")]
     #[default]
-    Running,
+    Queued,
+
+    /// A worker is actively analyzing the document
+    #[db_rename = "analyzing"]
+    #[serde(rename = "analyzing")]
+    Analyzing,
 
     /// Detection done; awaiting reviewer verification
     #[db_rename = "analyzed"]
@@ -43,10 +52,16 @@ pub enum PipelineRunStatus {
 }
 
 impl PipelineRunStatus {
-    /// Returns whether detection is in progress.
+    /// Returns whether the run is enqueued and not yet picked up by a worker.
     #[inline]
-    pub fn is_running(self) -> bool {
-        matches!(self, PipelineRunStatus::Running)
+    pub fn is_queued(self) -> bool {
+        matches!(self, PipelineRunStatus::Queued)
+    }
+
+    /// Returns whether a worker is actively analyzing the document.
+    #[inline]
+    pub fn is_analyzing(self) -> bool {
+        matches!(self, PipelineRunStatus::Analyzing)
     }
 
     /// Returns whether detection is done and the run awaits verification.
@@ -73,12 +88,21 @@ impl PipelineRunStatus {
         matches!(self, PipelineRunStatus::Cancelled)
     }
 
-    /// Returns whether the run is still active (running or awaiting review).
+    /// Returns whether detection is still pending (queued or analyzing).
+    #[inline]
+    pub fn is_detecting(self) -> bool {
+        matches!(
+            self,
+            PipelineRunStatus::Queued | PipelineRunStatus::Analyzing
+        )
+    }
+
+    /// Returns whether the run is still active (detecting or awaiting review).
     #[inline]
     pub fn is_active(self) -> bool {
         matches!(
             self,
-            PipelineRunStatus::Running | PipelineRunStatus::Analyzed
+            PipelineRunStatus::Queued | PipelineRunStatus::Analyzing | PipelineRunStatus::Analyzed
         )
     }
 

--- a/crates/nvisy-postgres/src/types/enums/webhook_event.rs
+++ b/crates/nvisy-postgres/src/types/enums/webhook_event.rs
@@ -99,6 +99,11 @@ pub enum WebhookEvent {
     #[serde(rename = "pipeline:run.started")]
     PipelineRunStarted,
 
+    /// A pipeline run's detection finished (findings ready for review)
+    #[db_rename = "pipeline:run.analyzed"]
+    #[serde(rename = "pipeline:run.analyzed")]
+    PipelineRunAnalyzed,
+
     /// A pipeline run finished successfully
     #[db_rename = "pipeline:run.completed"]
     #[serde(rename = "pipeline:run.completed")]
@@ -168,6 +173,7 @@ impl WebhookEvent {
                 | WebhookEvent::PipelineUpdated
                 | WebhookEvent::PipelineDeleted
                 | WebhookEvent::PipelineRunStarted
+                | WebhookEvent::PipelineRunAnalyzed
                 | WebhookEvent::PipelineRunCompleted
                 | WebhookEvent::PipelineRunFailed
         )
@@ -201,6 +207,7 @@ impl WebhookEvent {
             | WebhookEvent::PipelineUpdated
             | WebhookEvent::PipelineDeleted
             | WebhookEvent::PipelineRunStarted
+            | WebhookEvent::PipelineRunAnalyzed
             | WebhookEvent::PipelineRunCompleted
             | WebhookEvent::PipelineRunFailed => "pipeline",
             WebhookEvent::PolicyCreated
@@ -232,6 +239,7 @@ impl WebhookEvent {
             WebhookEvent::PipelineUpdated => "pipeline.updated",
             WebhookEvent::PipelineDeleted => "pipeline.deleted",
             WebhookEvent::PipelineRunStarted => "pipeline.run.started",
+            WebhookEvent::PipelineRunAnalyzed => "pipeline.run.analyzed",
             WebhookEvent::PipelineRunCompleted => "pipeline.run.completed",
             WebhookEvent::PipelineRunFailed => "pipeline.run.failed",
             WebhookEvent::PolicyCreated => "policy.created",

--- a/crates/nvisy-server/src/handler/pipeline_runs.rs
+++ b/crates/nvisy-server/src/handler/pipeline_runs.rs
@@ -417,7 +417,8 @@ async fn stream_pipeline_run_events(
     AuthState(auth_state): AuthState,
     WorkspaceContext(workspace): WorkspaceContext,
     Path(path_params): Path<PipelineRunPathParams>,
-) -> Result<SseResponse<impl Stream<Item = std::result::Result<Event, Infallible>>>> {
+) -> Result<SseResponse<impl Stream<Item = std::result::Result<Event, Infallible>>, RunStatusEvent>>
+{
     tracing::debug!(target: TRACING_TARGET, "Opening run status stream");
 
     let run_id = path_params.run_id.as_uuid();
@@ -478,7 +479,7 @@ async fn stream_pipeline_run_events(
         }
     };
 
-    Ok(SseResponse(
+    Ok(SseResponse::new(
         Sse::new(stream).keep_alive(KeepAlive::default()),
     ))
 }
@@ -512,7 +513,8 @@ fn stream_pipeline_run_events_docs(op: TransformOperation) -> TransformOperation
         .description(
             "Opens a Server-Sent Events stream of the run's status changes. \
              Emits the current status immediately, then each transition, and \
-             ends once the run settles (analyzed, failed, or cancelled). \
+             ends once the run settles (analyzed, failed, or cancelled). Each \
+             event's `data` is a `RunStatusEvent` (see the response schema). \
              Authenticate with a Bearer token via a `fetch`-based client; the \
              native `EventSource` cannot send an `Authorization` header.",
         )

--- a/crates/nvisy-server/src/handler/pipeline_runs.rs
+++ b/crates/nvisy-server/src/handler/pipeline_runs.rs
@@ -4,10 +4,13 @@
 //! and stores the findings; the run then awaits reviewer verification before
 //! redact consumes the verified findings and produces a redacted file.
 
+use std::convert::Infallible;
+
 use aide::axum::ApiRouter;
 use aide::transform::TransformOperation;
 use axum::extract::State;
 use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive, Sse};
 use nvisy_engine::policy::PolicyDefinition;
 use nvisy_postgres::model::{
     NewWorkspacePipelineRun, UpdateWorkspacePipelineRun, WorkspacePipeline, WorkspacePipelineRun,
@@ -32,8 +35,8 @@ use crate::handler::response::{ErrorResponse, PipelineRun, PipelineRunsPage};
 use crate::handler::utility::resolve_account_ref;
 use crate::handler::{Error, ErrorKind, Result};
 use crate::service::{
-    BlobService, CryptoService, DetectionJob, DetectionService, EngineService, ServiceState,
-    WebhookEmitter,
+    BlobService, CryptoService, DetectionJob, DetectionService, EngineService, RunStatusEvent,
+    ServiceState, WebhookEmitter,
 };
 
 /// Tracing target for pipeline run operations.
@@ -370,6 +373,76 @@ fn get_pipeline_run_docs(op: TransformOperation) -> TransformOperation {
         .response::<404, Json<ErrorResponse>>()
 }
 
+/// Streams a run's status changes as Server-Sent Events until detection settles.
+///
+/// Emits one `status` event with the run's current status immediately (so a
+/// client that connects after detection already finished still learns the
+/// state), then forwards each status change. The stream ends once the run leaves
+/// `running` — i.e. detection has produced `analyzed`, `failed`, or `cancelled`.
+///
+/// Authenticated like every other route (Bearer); browsers should consume it via
+/// a `fetch` stream rather than the native `EventSource`, which cannot send an
+/// `Authorization` header.
+#[tracing::instrument(
+    skip_all,
+    fields(
+        account_id = %auth_state.account_id,
+        workspace_id = %workspace.id,
+        run_id = %path_params.run_id,
+    )
+)]
+async fn stream_pipeline_run_events(
+    State(pg_client): State<PgClient>,
+    State(detection): State<DetectionService>,
+    AuthState(auth_state): AuthState,
+    WorkspaceContext(workspace): WorkspaceContext,
+    Path(path_params): Path<PipelineRunPathParams>,
+) -> Result<Sse<impl futures::Stream<Item = std::result::Result<Event, Infallible>>>> {
+    tracing::debug!(target: TRACING_TARGET, "Opening run status stream");
+
+    let mut conn = pg_client.get_connection().await?;
+    auth_state
+        .authorize_workspace(&mut conn, workspace.id, Permission::ViewPipelines)
+        .await?;
+
+    let (run, _pipeline) =
+        find_pipeline_run(&mut conn, workspace.id, path_params.run_id.as_uuid()).await?;
+    let run_id = run.id;
+    let current = run.status;
+
+    // Subscribe before dropping the connection so no status change published
+    // between the read above and the subscription is missed.
+    let mut updates = detection.subscribe_status(run_id).await?;
+
+    let stream = async_stream::stream! {
+        // Emit the current status first: covers the race where detection settled
+        // before this stream opened (no live event would ever arrive).
+        yield Ok(status_event(&RunStatusEvent { run_id, status: current }));
+        if current != PipelineRunStatus::Running {
+            return;
+        }
+
+        use futures::StreamExt as _;
+        while let Some(event) = updates.next().await {
+            let settled = event.status != PipelineRunStatus::Running;
+            yield Ok(status_event(&event));
+            if settled {
+                break;
+            }
+        }
+    };
+
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+/// Builds a `status` SSE event carrying the run's status change.
+fn status_event(event: &RunStatusEvent) -> Event {
+    Event::default()
+        .event("status")
+        .json_data(event)
+        .unwrap_or_else(|_| Event::default().event("status"))
+}
+
 /// Redacts a run using the reviewer-verified findings, storing the result.
 ///
 /// Consumes the analyzed run (which must be awaiting review), applies the
@@ -584,6 +657,12 @@ pub fn routes() -> ApiRouter<ServiceState> {
         .api_route(
             "/workspaces/{workspaceSlug}/runs/{runId}/",
             get_with(get_pipeline_run, get_pipeline_run_docs),
+        )
+        // SSE stream: registered as a plain route (a streaming body is not
+        // meaningfully represented in the OpenAPI document).
+        .route(
+            "/workspaces/{workspaceSlug}/runs/{runId}/events",
+            axum::routing::get(stream_pipeline_run_events),
         )
         .api_route(
             "/workspaces/{workspaceSlug}/runs/{runId}/redactions/",

--- a/crates/nvisy-server/src/handler/pipeline_runs.rs
+++ b/crates/nvisy-server/src/handler/pipeline_runs.rs
@@ -8,7 +8,6 @@ use aide::axum::ApiRouter;
 use aide::transform::TransformOperation;
 use axum::extract::State;
 use axum::http::StatusCode;
-use nvisy_engine::OcrMode;
 use nvisy_engine::policy::PolicyDefinition;
 use nvisy_postgres::model::{
     NewWorkspacePipelineRun, UpdateWorkspacePipelineRun, WorkspacePipeline, WorkspacePipelineRun,
@@ -17,7 +16,7 @@ use nvisy_postgres::query::{
     PipelineReferenceRepository, WorkspaceFileRepository, WorkspacePipelineRepository,
     WorkspacePipelineRunRepository, WorkspacePolicyRepository,
 };
-use nvisy_postgres::types::{OcrPolicy, PipelineRunStatus, WorkspaceSettings};
+use nvisy_postgres::types::{PipelineRunStatus, WorkspaceSettings};
 use nvisy_postgres::{PgClient, PgConn};
 use uuid::Uuid;
 
@@ -26,13 +25,16 @@ use crate::extract::{
     WorkspaceContext,
 };
 use crate::handler::request::{
-    CreatePipelineRun, CursorPagination, PipelineDefinition, PipelinePathParams,
-    PipelineRunPathParams, WorkspaceRunsQuery,
+    CreatePipelineRun, CursorPagination, PipelinePathParams, PipelineRunPathParams,
+    WorkspaceRunsQuery,
 };
 use crate::handler::response::{ErrorResponse, PipelineRun, PipelineRunsPage};
 use crate::handler::utility::resolve_account_ref;
 use crate::handler::{Error, ErrorKind, Result};
-use crate::service::{BlobService, CryptoService, EngineService, ServiceState, WebhookEmitter};
+use crate::service::{
+    BlobService, CryptoService, DetectionJob, DetectionService, EngineService, ServiceState,
+    WebhookEmitter,
+};
 
 /// Tracing target for pipeline run operations.
 const TRACING_TARGET: &str = "nvisy_server::handler::runs";
@@ -52,9 +54,7 @@ const TRACING_TARGET: &str = "nvisy_server::handler::runs";
 )]
 async fn create_pipeline_run(
     State(pg_client): State<PgClient>,
-    State(blob): State<BlobService>,
-    State(crypto): State<CryptoService>,
-    State(engine): State<EngineService>,
+    State(detection): State<DetectionService>,
     State(webhook_emitter): State<WebhookEmitter>,
     AuthState(auth_state): AuthState,
     WorkspaceContext(workspace): WorkspaceContext,
@@ -100,15 +100,22 @@ async fn create_pipeline_run(
         ));
     }
 
+    // Validate synchronously so a bad request fails fast (4xx) rather than as a
+    // run that immediately fails in the worker.
     let file = conn
         .find_file_in_workspace(pipeline.workspace_id, request.file_id)
         .await?
         .ok_or_else(|| Error::not_found("file"))?;
 
-    let definition = PipelineDefinition::from_parts(pipeline.definition.clone(), Vec::new())
-        .map_err(serialize_error)?;
+    if conn.list_pipeline_policy_ids(pipeline.id).await?.is_empty() {
+        return Err(ErrorKind::BadRequest
+            .with_message("Pipeline has no policies; attach at least one before running")
+            .with_resource("pipeline"));
+    }
 
-    // Create the run first so its id is the engine correlation id.
+    // Create the run (its id is the engine correlation id) and enqueue detection
+    // for the worker. The response returns immediately; the client learns the
+    // findings are ready via the run's status (SSE at `.../events` or a re-read).
     let new_run = NewWorkspacePipelineRun {
         pipeline_id: pipeline.id,
         input_file_id: file.id,
@@ -118,6 +125,29 @@ async fn create_pipeline_run(
         ..Default::default()
     };
     let run = conn.create_workspace_pipeline_run(new_run).await?;
+
+    let job = DetectionJob {
+        workspace_id: workspace.id,
+        run_id: run.id,
+        scope: request.scope,
+    };
+    if let Err(err) = detection.enqueue(job).await {
+        // Enqueue failed, so the worker will never pick this run up: fail it now
+        // rather than leaving it stuck in `Running`.
+        fail_run(
+            &mut conn,
+            &webhook_emitter,
+            workspace.id,
+            run.id,
+            auth_state.account_id,
+        )
+        .await;
+        return Err(err);
+    }
+
+    detection
+        .broadcast_status(run.id, PipelineRunStatus::Running)
+        .await;
 
     if let Err(err) = webhook_emitter
         .emit_pipeline_run_started(
@@ -136,82 +166,12 @@ async fn create_pipeline_run(
         );
     }
 
-    // Map the workspace's OCR policy to the engine's per-run mode. `Force` renders
-    // every page at the engine's default DPI (no workspace DPI knob).
-    let ocr_mode = match WorkspaceSettings::from_value(&workspace.settings).ocr {
-        OcrPolicy::Auto => OcrMode::Auto,
-        OcrPolicy::Force => OcrMode::force(),
-        OcrPolicy::Never => OcrMode::Never,
-    };
-
-    // Build the analyzer params from the pipeline's intent; the deployment's
-    // recognizer lineups and enrichers are engine-owned.
-    let params = engine.analyzer_params(&definition, request.scope, ocr_mode);
-
-    let document = blob.build_document(&file, run.id).await?;
-
-    // The pipeline's policies own the label vocabulary: detection derives its
-    // catalog from them, so the analysis emits exactly what the policies can act
-    // on. Resolved before analyze and reused verbatim at redact.
-    let policies = resolve_policies(&mut conn, &crypto, workspace.id, pipeline.id).await?;
-    if policies.is_empty() {
-        fail_run(
-            &mut conn,
-            &webhook_emitter,
-            workspace.id,
-            run.id,
-            auth_state.account_id,
-        )
-        .await;
-        return Err(ErrorKind::BadRequest
-            .with_message("Pipeline has no policies; attach at least one before running")
-            .with_resource("pipeline"));
-    }
-
-    let analyzed = match engine.analyze(document, &policies, &params).await {
-        Ok(analyzed) => analyzed,
-        Err(err) => {
-            fail_run(
-                &mut conn,
-                &webhook_emitter,
-                workspace.id,
-                run.id,
-                auth_state.account_id,
-            )
-            .await;
-            return Err(err.into());
-        }
-    };
-
-    // The analysis is a map of detected PII; encrypt it and record it as an
-    // audit-kind file, keeping only its id on the run.
-    let workspace_settings = WorkspaceSettings::from_value(&workspace.settings).retention;
-    let audit_file_id = blob
-        .store_analyzed_document(
-            &mut conn,
-            &pipeline,
-            &workspace_settings,
-            auth_state.account_id,
-            &analyzed,
-        )
-        .await?;
-    let run = conn
-        .update_workspace_pipeline_run(
-            run.id,
-            UpdateWorkspacePipelineRun {
-                status: Some(PipelineRunStatus::Analyzed),
-                audit_file_id: Some(Some(audit_file_id)),
-                ..Default::default()
-            },
-        )
-        .await?;
-
-    tracing::info!(target: TRACING_TARGET, run_id = %run.id, "Pipeline run analyzed");
+    tracing::info!(target: TRACING_TARGET, run_id = %run.id, "Pipeline run enqueued for detection");
 
     let trigger = resolve_account_ref(&mut conn, run.account_id).await?;
 
     Ok((
-        StatusCode::CREATED,
+        StatusCode::ACCEPTED,
         Json(PipelineRun::from_model(
             run,
             pipeline.slug,
@@ -224,14 +184,19 @@ async fn create_pipeline_run(
 fn create_pipeline_run_docs(op: TransformOperation) -> TransformOperation {
     op.summary("Start a run (detect)")
         .description(
-            "Analyzes a file with the pipeline's configuration and returns the run \
-             holding the findings for review. Accepts an Idempotency-Key header.",
+            "Starts detection for a file and returns 202 with the run in the \
+             `running` state; the analysis runs in the background. Watch the run's \
+             status via the SSE stream at `.../runs/{runId}/events` (or re-read the \
+             run) and fetch the findings from `.../runs/{runId}/detections/` once it \
+             reaches `analyzed`. A repeated Idempotency-Key returns the existing run.",
         )
-        .response::<201, Json<PipelineRun>>()
+        .response::<202, Json<PipelineRun>>()
+        .response::<200, Json<PipelineRun>>()
         .response::<400, Json<ErrorResponse>>()
         .response::<401, Json<ErrorResponse>>()
         .response::<403, Json<ErrorResponse>>()
         .response::<404, Json<ErrorResponse>>()
+        .response::<409, Json<ErrorResponse>>()
 }
 
 /// Lists runs for a specific pipeline.
@@ -573,13 +538,6 @@ async fn fail_run(
             "Failed to emit pipeline:run.failed webhook event"
         );
     }
-}
-
-/// Maps a definition (de)serialization failure to an internal error.
-fn serialize_error(error: serde_json::Error) -> Error<'static> {
-    ErrorKind::InternalServerError
-        .with_message("Failed to process pipeline definition")
-        .with_context(error.to_string())
 }
 
 /// Finds a pipeline within a workspace by slug or returns NotFound.

--- a/crates/nvisy-server/src/handler/pipeline_runs.rs
+++ b/crates/nvisy-server/src/handler/pipeline_runs.rs
@@ -13,13 +13,12 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use futures::{Stream, StreamExt};
-use nvisy_engine::policy::PolicyDefinition;
 use nvisy_postgres::model::{
     NewWorkspacePipelineRun, UpdateWorkspacePipelineRun, WorkspacePipeline, WorkspacePipelineRun,
 };
 use nvisy_postgres::query::{
     PipelineReferenceRepository, WorkspaceFileRepository, WorkspacePipelineRepository,
-    WorkspacePipelineRunRepository, WorkspacePolicyRepository,
+    WorkspacePipelineRunRepository,
 };
 use nvisy_postgres::types::{PipelineRunStatus, WorkspaceSettings};
 use nvisy_postgres::{PgClient, PgConn};
@@ -30,15 +29,15 @@ use crate::extract::{
     WorkspaceContext,
 };
 use crate::handler::request::{
-    CreatePipelineRun, CursorPagination, PipelinePathParams, PipelineRunPathParams,
-    WorkspaceRunsQuery,
+    CreatePipelineRun, CursorPagination, PipelineDefinition, PipelinePathParams,
+    PipelineRunPathParams, WorkspaceRunsQuery,
 };
 use crate::handler::response::{ErrorResponse, PipelineRun, PipelineRunsPage};
 use crate::handler::utility::{SseResponse, resolve_account_ref};
 use crate::handler::{Error, ErrorKind, Result};
 use crate::service::{
     BlobService, CryptoService, DetectionJob, DetectionService, EngineService, RunStatusEvent,
-    ServiceState, WebhookEmitter,
+    ServiceState, WebhookEmitter, fail_run, resolve_policies,
 };
 
 /// Tracing target for pipeline run operations.
@@ -118,6 +117,18 @@ async fn create_pipeline_run(
             .with_resource("pipeline"));
     }
 
+    // Decode the pipeline definition now so an undecodable definition fails the
+    // request synchronously (400) instead of returning 202 and failing later in
+    // the worker. The decoded value is rebuilt in the worker from the same
+    // stored bytes; this is validation only.
+    let _validated = PipelineDefinition::from_parts(pipeline.definition.clone(), Vec::new())
+        .map_err(|err| {
+            ErrorKind::BadRequest
+                .with_message("Pipeline definition is invalid")
+                .with_resource("pipeline")
+                .with_context(err.to_string())
+        })?;
+
     // Create the run (its id is the engine correlation id) and enqueue detection
     // for the worker. The response returns immediately; the client learns the
     // findings are ready via the run's status (SSE at `.../events` or a re-read).
@@ -125,7 +136,7 @@ async fn create_pipeline_run(
         pipeline_id: pipeline.id,
         input_file_id: file.id,
         account_id: auth_state.account_id,
-        status: Some(PipelineRunStatus::Running),
+        status: Some(PipelineRunStatus::Queued),
         idempotency_key: idempotency_key.clone(),
         ..Default::default()
     };
@@ -138,20 +149,22 @@ async fn create_pipeline_run(
     };
     if let Err(err) = detection.enqueue(job).await {
         // Enqueue failed, so the worker will never pick this run up: fail it now
-        // rather than leaving it stuck in `Running`.
+        // rather than leaving it stuck in `Queued`.
         fail_run(
             &mut conn,
+            &detection,
             &webhook_emitter,
             workspace.id,
             run.id,
             auth_state.account_id,
+            "Failed to enqueue detection",
         )
         .await;
         return Err(err);
     }
 
     detection
-        .broadcast_status(run.id, PipelineRunStatus::Running)
+        .broadcast_status(run.id, PipelineRunStatus::Queued)
         .await;
 
     if let Err(err) = webhook_emitter
@@ -380,7 +393,12 @@ fn get_pipeline_run_docs(op: TransformOperation) -> TransformOperation {
 /// Emits one `status` event with the run's current status immediately (so a
 /// client that connects after detection already finished still learns the
 /// state), then forwards each status change. The stream ends once the run leaves
-/// `running` — i.e. detection has produced `analyzed`, `failed`, or `cancelled`.
+/// the detecting phase (`queued`/`analyzing`) — i.e. detection has produced
+/// `analyzed`, or the run `failed`/`cancelled`.
+///
+/// Live status changes arrive over a best-effort core-NATS broadcast; if none
+/// arrives within a short interval the authoritative run row is re-read from the
+/// database, so a dropped broadcast never leaves the stream hanging.
 ///
 /// Authenticated like every other route (Bearer); browsers should consume it via
 /// a `fetch` stream rather than the native `EventSource`, which cannot send an
@@ -402,33 +420,60 @@ async fn stream_pipeline_run_events(
 ) -> Result<SseResponse<impl Stream<Item = std::result::Result<Event, Infallible>>>> {
     tracing::debug!(target: TRACING_TARGET, "Opening run status stream");
 
+    let run_id = path_params.run_id.as_uuid();
     let mut conn = pg_client.get_connection().await?;
     auth_state
         .authorize_workspace(&mut conn, workspace.id, Permission::ViewPipelines)
         .await?;
 
-    let (run, _pipeline) =
-        find_pipeline_run(&mut conn, workspace.id, path_params.run_id.as_uuid()).await?;
-    let run_id = run.id;
-    let current = run.status;
-
-    // Subscribe before dropping the connection so no status change published
-    // between the read above and the subscription is missed.
+    // Subscribe BEFORE reading the current status: core-NATS broadcasts are not
+    // replayed, so a terminal status published between the read and the
+    // subscription going live would otherwise be lost and the stream would hang.
     let mut updates = detection.subscribe_status(run_id).await?;
+
+    // Confirm the run exists (and is workspace-scoped) so a bad id 404s here
+    // rather than opening an empty stream.
+    let (run, _pipeline) = find_pipeline_run(&mut conn, workspace.id, run_id).await?;
+    let current = run.status;
+    drop(conn);
 
     let stream = stream! {
         // Emit the current status first: covers the race where detection settled
-        // before this stream opened (no live event would ever arrive).
+        // before the subscription was live (no live event would ever arrive).
         yield Ok(status_event(&RunStatusEvent { run_id, status: current }));
-        if current != PipelineRunStatus::Running {
+        if !current.is_detecting() {
             return;
         }
 
-        while let Some(event) = updates.next().await {
-            let settled = event.status != PipelineRunStatus::Running;
-            yield Ok(status_event(&event));
-            if settled {
-                break;
+        loop {
+            match tokio::time::timeout(STATUS_POLL_INTERVAL, updates.next()).await {
+                // A live broadcast arrived; forward it and stop once detection settles.
+                Ok(Some(event)) => {
+                    let settled = !event.status.is_detecting();
+                    yield Ok(status_event(&event));
+                    if settled {
+                        break;
+                    }
+                }
+                // The subscription ended; fall back to the DB so the client still
+                // learns the final status.
+                Ok(None) => {
+                    if let Some(status) = reread_run_status(&pg_client, workspace.id, run_id).await {
+                        yield Ok(status_event(&RunStatusEvent { run_id, status }));
+                    }
+                    break;
+                }
+                // No broadcast within the interval: re-read the authoritative run
+                // row. This recovers a dropped best-effort broadcast (core NATS is
+                // at-most-once) instead of hanging on keep-alive forever.
+                Err(_) => {
+                    if let Some(status) = reread_run_status(&pg_client, workspace.id, run_id).await {
+                        yield Ok(status_event(&RunStatusEvent { run_id, status }));
+                        if !status.is_detecting() {
+                            break;
+                        }
+                    }
+                }
             }
         }
     };
@@ -436,6 +481,29 @@ async fn stream_pipeline_run_events(
     Ok(SseResponse(
         Sse::new(stream).keep_alive(KeepAlive::default()),
     ))
+}
+
+/// How long the status stream waits for a live broadcast before re-reading the
+/// authoritative run row from the database (the fallback for a dropped
+/// best-effort broadcast).
+const STATUS_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Re-reads a run's current status from the database, returning `None` if the
+/// run can no longer be read (missing, or a transient error — the next poll
+/// retries).
+async fn reread_run_status(
+    pg_client: &PgClient,
+    workspace_id: Uuid,
+    run_id: Uuid,
+) -> Option<PipelineRunStatus> {
+    let mut conn = pg_client.get_connection().await.ok()?;
+    match find_pipeline_run(&mut conn, workspace_id, run_id).await {
+        Ok((run, _pipeline)) => Some(run.status),
+        Err(err) => {
+            tracing::debug!(target: TRACING_TARGET, error = %err, %run_id, "Failed to re-read run status");
+            None
+        }
+    }
 }
 
 /// OpenAPI documentation for the run status SSE stream.
@@ -600,37 +668,6 @@ fn redact_pipeline_run_docs(op: TransformOperation) -> TransformOperation {
         .response::<409, Json<ErrorResponse>>()
 }
 
-/// Marks a run failed (best effort) after an engine error and emits the
-/// `pipeline:run.failed` webhook event.
-async fn fail_run(
-    conn: &mut PgConn,
-    webhook_emitter: &WebhookEmitter,
-    workspace_id: uuid::Uuid,
-    run_id: uuid::Uuid,
-    triggered_by: uuid::Uuid,
-) {
-    let update = UpdateWorkspacePipelineRun {
-        status: Some(PipelineRunStatus::Failed),
-        completed_at: Some(Some(jiff::Timestamp::now().into())),
-        ..Default::default()
-    };
-    if let Err(err) = conn.update_workspace_pipeline_run(run_id, update).await {
-        tracing::warn!(target: TRACING_TARGET, error = %err, "Failed to mark run failed");
-    }
-
-    if let Err(err) = webhook_emitter
-        .emit_pipeline_run_failed(workspace_id, run_id, Some(triggered_by), None)
-        .await
-    {
-        tracing::warn!(
-            target: TRACING_TARGET,
-            error = %err,
-            run_id = %run_id,
-            "Failed to emit pipeline:run.failed webhook event"
-        );
-    }
-}
-
 /// Finds a pipeline within a workspace by slug or returns NotFound.
 async fn find_pipeline(
     conn: &mut PgConn,
@@ -685,22 +722,4 @@ pub fn routes() -> ApiRouter<ServiceState> {
             post_with(redact_pipeline_run, redact_pipeline_run_docs),
         )
         .with_path_items(|item| item.tag("Pipeline Runs"))
-}
-
-/// Resolves a pipeline's live policy references into decrypted engine policies.
-async fn resolve_policies(
-    conn: &mut PgConn,
-    crypto: &CryptoService,
-    workspace_id: Uuid,
-    pipeline_id: Uuid,
-) -> Result<Vec<PolicyDefinition>> {
-    let ids = conn.list_pipeline_policy_ids(pipeline_id).await?;
-    let mut policies = Vec::with_capacity(ids.len());
-    for id in ids {
-        if let Some(model) = conn.find_policy_in_workspace(workspace_id, id).await? {
-            policies
-                .push(crypto.decrypt_json::<PolicyDefinition>(workspace_id, &model.definition)?);
-        }
-    }
-    Ok(policies)
 }

--- a/crates/nvisy-server/src/handler/pipeline_runs.rs
+++ b/crates/nvisy-server/src/handler/pipeline_runs.rs
@@ -8,9 +8,11 @@ use std::convert::Infallible;
 
 use aide::axum::ApiRouter;
 use aide::transform::TransformOperation;
+use async_stream::stream;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
+use futures::{Stream, StreamExt};
 use nvisy_engine::policy::PolicyDefinition;
 use nvisy_postgres::model::{
     NewWorkspacePipelineRun, UpdateWorkspacePipelineRun, WorkspacePipeline, WorkspacePipelineRun,
@@ -32,7 +34,7 @@ use crate::handler::request::{
     WorkspaceRunsQuery,
 };
 use crate::handler::response::{ErrorResponse, PipelineRun, PipelineRunsPage};
-use crate::handler::utility::resolve_account_ref;
+use crate::handler::utility::{SseResponse, resolve_account_ref};
 use crate::handler::{Error, ErrorKind, Result};
 use crate::service::{
     BlobService, CryptoService, DetectionJob, DetectionService, EngineService, RunStatusEvent,
@@ -397,7 +399,7 @@ async fn stream_pipeline_run_events(
     AuthState(auth_state): AuthState,
     WorkspaceContext(workspace): WorkspaceContext,
     Path(path_params): Path<PipelineRunPathParams>,
-) -> Result<Sse<impl futures::Stream<Item = std::result::Result<Event, Infallible>>>> {
+) -> Result<SseResponse<impl Stream<Item = std::result::Result<Event, Infallible>>>> {
     tracing::debug!(target: TRACING_TARGET, "Opening run status stream");
 
     let mut conn = pg_client.get_connection().await?;
@@ -414,7 +416,7 @@ async fn stream_pipeline_run_events(
     // between the read above and the subscription is missed.
     let mut updates = detection.subscribe_status(run_id).await?;
 
-    let stream = async_stream::stream! {
+    let stream = stream! {
         // Emit the current status first: covers the race where detection settled
         // before this stream opened (no live event would ever arrive).
         yield Ok(status_event(&RunStatusEvent { run_id, status: current }));
@@ -422,7 +424,6 @@ async fn stream_pipeline_run_events(
             return;
         }
 
-        use futures::StreamExt as _;
         while let Some(event) = updates.next().await {
             let settled = event.status != PipelineRunStatus::Running;
             yield Ok(status_event(&event));
@@ -432,7 +433,24 @@ async fn stream_pipeline_run_events(
         }
     };
 
-    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+    Ok(SseResponse(
+        Sse::new(stream).keep_alive(KeepAlive::default()),
+    ))
+}
+
+/// OpenAPI documentation for the run status SSE stream.
+fn stream_pipeline_run_events_docs(op: TransformOperation) -> TransformOperation {
+    op.summary("Stream pipeline run status")
+        .description(
+            "Opens a Server-Sent Events stream of the run's status changes. \
+             Emits the current status immediately, then each transition, and \
+             ends once the run settles (analyzed, failed, or cancelled). \
+             Authenticate with a Bearer token via a `fetch`-based client; the \
+             native `EventSource` cannot send an `Authorization` header.",
+        )
+        .response::<401, Json<ErrorResponse>>()
+        .response::<403, Json<ErrorResponse>>()
+        .response::<404, Json<ErrorResponse>>()
 }
 
 /// Builds a `status` SSE event carrying the run's status change.
@@ -658,11 +676,9 @@ pub fn routes() -> ApiRouter<ServiceState> {
             "/workspaces/{workspaceSlug}/runs/{runId}/",
             get_with(get_pipeline_run, get_pipeline_run_docs),
         )
-        // SSE stream: registered as a plain route (a streaming body is not
-        // meaningfully represented in the OpenAPI document).
-        .route(
+        .api_route(
             "/workspaces/{workspaceSlug}/runs/{runId}/events",
-            axum::routing::get(stream_pipeline_run_events),
+            get_with(stream_pipeline_run_events, stream_pipeline_run_events_docs),
         )
         .api_route(
             "/workspaces/{workspaceSlug}/runs/{runId}/redactions/",

--- a/crates/nvisy-server/src/handler/response/pipeline_runs.rs
+++ b/crates/nvisy-server/src/handler/response/pipeline_runs.rs
@@ -36,6 +36,9 @@ pub struct PipelineRun {
     /// The detections are available to fetch from the run's `detections`
     /// endpoint once this reaches `analyzed`.
     pub status: PipelineRunStatus,
+    /// Human-readable failure reason, present only when the run `failed`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
     /// Non-encrypted metadata for filtering/display.
     pub metadata: serde_json::Value,
     /// When the run started.
@@ -57,6 +60,14 @@ impl PipelineRun {
         workspace_slug: Handle,
         triggered_by: AccountRef,
     ) -> Self {
+        // Surface a failure reason (written to metadata.error by the worker /
+        // enqueue-failure path) as a dedicated field for a failed run.
+        let error = run
+            .metadata
+            .get("error")
+            .and_then(|value| value.as_str())
+            .map(str::to_owned);
+
         Self {
             id: RunId::from_uuid(run.id),
             pipeline_slug,
@@ -66,6 +77,7 @@ impl PipelineRun {
             triggered_by,
             trigger_type: run.trigger_type,
             status: run.status,
+            error,
             metadata: run.metadata,
             started_at: run.started_at.into(),
             completed_at: run.completed_at.map(Into::into),

--- a/crates/nvisy-server/src/handler/utility/mod.rs
+++ b/crates/nvisy-server/src/handler/utility/mod.rs
@@ -3,7 +3,9 @@
 mod accounts;
 mod avatar;
 mod custom_routes;
+mod sse;
 
 pub use accounts::{build_password_user_inputs, resolve_account_ref};
 pub use avatar::{avatar_response, read_image_field};
 pub use custom_routes::{BuiltinModule, CustomRoutes, RouterMapFn};
+pub use sse::SseResponse;

--- a/crates/nvisy-server/src/handler/utility/sse.rs
+++ b/crates/nvisy-server/src/handler/utility/sse.rs
@@ -3,42 +3,79 @@
 //! Axum's [`Sse`] does not implement aide's [`OperationOutput`], so a handler
 //! returning it cannot be registered via `api_route`/`get_with` (no OpenAPI is
 //! produced). [`SseResponse`] wraps it, delegating [`IntoResponse`] to the inner
-//! stream while advertising a `200 text/event-stream` response to the schema.
+//! stream while advertising a `200 text/event-stream` response whose media type
+//! carries the JSON Schema of one event's `data` payload.
+
+use std::marker::PhantomData;
 
 use aide::OperationOutput;
 use aide::generate::GenContext;
-use aide::openapi::{MediaType, Operation, Response, StatusCode};
+use aide::openapi::{MediaType, Operation, Response, SchemaObject, StatusCode};
 use axum::response::sse::Sse;
 use axum::response::{IntoResponse, Response as AxumResponse};
+use schemars::JsonSchema;
 
 /// An [`Sse`] response that also produces OpenAPI documentation.
 ///
 /// Wrap a handler's [`Sse`] in this so the route can be registered with
 /// `api_route`/`get_with` and appear in the generated schema as a
-/// `text/event-stream` endpoint.
+/// `text/event-stream` endpoint. The `E` type parameter is the payload carried
+/// in each event's `data` field; its schema is attached to the media type so
+/// consumers can see the shape of the events they will receive.
+///
+/// OpenAPI has no first-class model for the SSE wire framing (`event:`/`data:`
+/// lines), so this documents the per-event `data` payload schema — the standard,
+/// meaningful thing to expose for an event stream.
 #[must_use = "responses do nothing unless returned from a handler"]
-pub struct SseResponse<S>(pub Sse<S>);
+pub struct SseResponse<S, E> {
+    inner: Sse<S>,
+    _event: PhantomData<fn() -> E>,
+}
 
-impl<S> IntoResponse for SseResponse<S>
+impl<S, E> SseResponse<S, E> {
+    /// Wraps an [`Sse`] whose events carry an `E` payload in their `data` field.
+    pub fn new(inner: Sse<S>) -> Self {
+        Self {
+            inner,
+            _event: PhantomData,
+        }
+    }
+}
+
+impl<S, E> IntoResponse for SseResponse<S, E>
 where
     Sse<S>: IntoResponse,
 {
     fn into_response(self) -> AxumResponse {
-        self.0.into_response()
+        self.inner.into_response()
     }
 }
 
-impl<S> OperationOutput for SseResponse<S> {
-    type Inner = Self;
+impl<S, E> OperationOutput for SseResponse<S, E>
+where
+    E: JsonSchema,
+{
+    type Inner = E;
 
-    fn operation_response(_ctx: &mut GenContext, _operation: &mut Operation) -> Option<Response> {
+    fn operation_response(ctx: &mut GenContext, _operation: &mut Operation) -> Option<Response> {
+        let json_schema = ctx.schema.subschema_for::<E>();
+
         let mut response = Response {
-            description: "Server-sent event stream".to_owned(),
+            description: "Server-sent event stream; each event's `data` is the payload below."
+                .to_owned(),
             ..Default::default()
         };
-        response
-            .content
-            .insert("text/event-stream".to_owned(), MediaType::default());
+        response.content.insert(
+            "text/event-stream".to_owned(),
+            MediaType {
+                schema: Some(SchemaObject {
+                    json_schema,
+                    example: None,
+                    external_docs: None,
+                }),
+                ..Default::default()
+            },
+        );
         Some(response)
     }
 

--- a/crates/nvisy-server/src/handler/utility/sse.rs
+++ b/crates/nvisy-server/src/handler/utility/sse.rs
@@ -1,0 +1,54 @@
+//! OpenAPI-documented wrapper around an [`Sse`] response.
+//!
+//! Axum's [`Sse`] does not implement aide's [`OperationOutput`], so a handler
+//! returning it cannot be registered via `api_route`/`get_with` (no OpenAPI is
+//! produced). [`SseResponse`] wraps it, delegating [`IntoResponse`] to the inner
+//! stream while advertising a `200 text/event-stream` response to the schema.
+
+use aide::OperationOutput;
+use aide::generate::GenContext;
+use aide::openapi::{MediaType, Operation, Response, StatusCode};
+use axum::response::sse::Sse;
+use axum::response::{IntoResponse, Response as AxumResponse};
+
+/// An [`Sse`] response that also produces OpenAPI documentation.
+///
+/// Wrap a handler's [`Sse`] in this so the route can be registered with
+/// `api_route`/`get_with` and appear in the generated schema as a
+/// `text/event-stream` endpoint.
+#[must_use = "responses do nothing unless returned from a handler"]
+pub struct SseResponse<S>(pub Sse<S>);
+
+impl<S> IntoResponse for SseResponse<S>
+where
+    Sse<S>: IntoResponse,
+{
+    fn into_response(self) -> AxumResponse {
+        self.0.into_response()
+    }
+}
+
+impl<S> OperationOutput for SseResponse<S> {
+    type Inner = Self;
+
+    fn operation_response(_ctx: &mut GenContext, _operation: &mut Operation) -> Option<Response> {
+        let mut response = Response {
+            description: "Server-sent event stream".to_owned(),
+            ..Default::default()
+        };
+        response
+            .content
+            .insert("text/event-stream".to_owned(), MediaType::default());
+        Some(response)
+    }
+
+    fn inferred_responses(
+        ctx: &mut GenContext,
+        operation: &mut Operation,
+    ) -> Vec<(Option<StatusCode>, Response)> {
+        match Self::operation_response(ctx, operation) {
+            Some(response) => Vec::from([(Some(StatusCode::Code(200)), response)]),
+            None => Vec::new(),
+        }
+    }
+}

--- a/crates/nvisy-server/src/service/detection/job.rs
+++ b/crates/nvisy-server/src/service/detection/job.rs
@@ -2,6 +2,7 @@
 
 use nvisy_engine::plan::ScopeParams;
 use nvisy_postgres::types::PipelineRunStatus;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -27,7 +28,7 @@ pub struct DetectionJob {
 ///
 /// Fan-out to any watching SSE connections; the run row in Postgres remains the
 /// source of truth, so a missed broadcast is recoverable by re-reading the run.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RunStatusEvent {
     /// The run whose status changed.

--- a/crates/nvisy-server/src/service/detection/job.rs
+++ b/crates/nvisy-server/src/service/detection/job.rs
@@ -1,0 +1,43 @@
+//! Detection job and run-status event types.
+
+use nvisy_engine::plan::ScopeParams;
+use nvisy_postgres::types::PipelineRunStatus;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// A queued request to run detection for a pipeline run.
+///
+/// Published to the `DetectionStream` work-queue by the create-run handler and
+/// consumed by the [`DetectionWorker`](super::DetectionWorker). The worker
+/// re-loads the run, pipeline, file, and policies from the ids; only the
+/// caller-supplied per-request scope, which is not otherwise persisted, travels
+/// on the job.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DetectionJob {
+    /// Workspace owning the run.
+    pub workspace_id: Uuid,
+    /// The run to analyze.
+    pub run_id: Uuid,
+    /// Caller-supplied per-request scope override, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<ScopeParams>,
+}
+
+/// A run's status change, broadcast on the core-NATS subject [`run_subject`].
+///
+/// Fan-out to any watching SSE connections; the run row in Postgres remains the
+/// source of truth, so a missed broadcast is recoverable by re-reading the run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunStatusEvent {
+    /// The run whose status changed.
+    pub run_id: Uuid,
+    /// The run's new status.
+    pub status: PipelineRunStatus,
+}
+
+/// The core-NATS subject a run's status changes are broadcast on.
+#[must_use]
+pub fn run_subject(run_id: Uuid) -> String {
+    format!("pipeline.runs.{run_id}.status")
+}

--- a/crates/nvisy-server/src/service/detection/mod.rs
+++ b/crates/nvisy-server/src/service/detection/mod.rs
@@ -8,8 +8,10 @@
 
 mod job;
 mod service;
+mod support;
 mod worker;
 
 pub use job::{DetectionJob, RunStatusEvent, run_subject};
 pub use service::DetectionService;
+pub(crate) use support::{fail_run, resolve_policies};
 pub use worker::DetectionWorker;

--- a/crates/nvisy-server/src/service/detection/mod.rs
+++ b/crates/nvisy-server/src/service/detection/mod.rs
@@ -1,0 +1,13 @@
+//! Async pipeline detection.
+//!
+//! A pipeline run is created synchronously by the API, then its detection
+//! (analyze) is enqueued to the `DetectionStream` work-queue and handled by the
+//! [`DetectionWorker`] off the request thread. Status changes are broadcast on a
+//! core-NATS subject (see [`run_subject`]) for SSE watchers and emitted as
+//! webhook events.
+
+mod job;
+mod worker;
+
+pub use job::{DetectionJob, RunStatusEvent, run_subject};
+pub use worker::DetectionWorker;

--- a/crates/nvisy-server/src/service/detection/mod.rs
+++ b/crates/nvisy-server/src/service/detection/mod.rs
@@ -7,7 +7,9 @@
 //! webhook events.
 
 mod job;
+mod service;
 mod worker;
 
 pub use job::{DetectionJob, RunStatusEvent, run_subject};
+pub use service::DetectionService;
 pub use worker::DetectionWorker;

--- a/crates/nvisy-server/src/service/detection/service.rs
+++ b/crates/nvisy-server/src/service/detection/service.rs
@@ -1,0 +1,71 @@
+//! Detection enqueue service.
+//!
+//! The request-side counterpart to the [`DetectionWorker`](super::DetectionWorker):
+//! publishes a run's detection to the `DetectionStream` work-queue and broadcasts
+//! its status on the run's core-NATS subject. Injected into the create-run
+//! handler so the handler stays thin and the NATS wiring lives in one place.
+
+use nvisy_nats::NatsClient;
+use nvisy_nats::stream::DetectionStream;
+use nvisy_postgres::types::PipelineRunStatus;
+use uuid::Uuid;
+
+use super::job::{DetectionJob, RunStatusEvent, run_subject};
+use crate::handler::Result;
+
+/// Enqueues pipeline detection jobs and broadcasts run-status changes.
+///
+/// Cheaply cloneable (holds only a [`NatsClient`], which is `Arc`-backed).
+#[derive(Clone)]
+#[must_use = "service does nothing unless you enqueue or broadcast with it"]
+pub struct DetectionService {
+    nats: NatsClient,
+}
+
+impl DetectionService {
+    /// Creates a new [`DetectionService`].
+    pub fn new(nats: NatsClient) -> Self {
+        Self { nats }
+    }
+
+    /// Enqueues a run's detection onto the work-queue for the worker to pick up.
+    pub async fn enqueue(&self, job: DetectionJob) -> Result<()> {
+        let publisher = self
+            .nats
+            .event_publisher::<DetectionJob, DetectionStream>()
+            .await?;
+        publisher.publish(&job).await?;
+        Ok(())
+    }
+
+    /// Broadcasts a run's status change on its core-NATS subject (best-effort;
+    /// the run row is authoritative, so a dropped broadcast is recoverable).
+    pub async fn broadcast_status(&self, run_id: Uuid, status: PipelineRunStatus) {
+        let event = RunStatusEvent { run_id, status };
+        if let Err(err) = self
+            .nats
+            .publish_broadcast(run_subject(run_id), &event)
+            .await
+        {
+            tracing::debug!(
+                target: "nvisy_server::service::detection",
+                error = %err,
+                "Failed to broadcast run status",
+            );
+        }
+    }
+
+    /// Subscribes to a run's status broadcasts, yielding each [`RunStatusEvent`].
+    ///
+    /// Used by the SSE endpoint to forward status changes to a watching client.
+    pub async fn subscribe_status(
+        &self,
+        run_id: Uuid,
+    ) -> Result<impl futures::Stream<Item = RunStatusEvent> + Send> {
+        let stream = self
+            .nats
+            .subscribe_broadcast::<RunStatusEvent>(run_subject(run_id))
+            .await?;
+        Ok(stream)
+    }
+}

--- a/crates/nvisy-server/src/service/detection/service.rs
+++ b/crates/nvisy-server/src/service/detection/service.rs
@@ -6,7 +6,7 @@
 //! handler so the handler stays thin and the NATS wiring lives in one place.
 
 use nvisy_nats::NatsClient;
-use nvisy_nats::stream::DetectionStream;
+use nvisy_nats::stream::{BroadcastStream, DetectionStream};
 use nvisy_postgres::types::PipelineRunStatus;
 use uuid::Uuid;
 
@@ -58,10 +58,7 @@ impl DetectionService {
     /// Subscribes to a run's status broadcasts, yielding each [`RunStatusEvent`].
     ///
     /// Used by the SSE endpoint to forward status changes to a watching client.
-    pub async fn subscribe_status(
-        &self,
-        run_id: Uuid,
-    ) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = RunStatusEvent> + Send>>> {
+    pub async fn subscribe_status(&self, run_id: Uuid) -> Result<BroadcastStream<RunStatusEvent>> {
         let stream = self
             .nats
             .subscribe_broadcast::<RunStatusEvent>(run_subject(run_id))

--- a/crates/nvisy-server/src/service/detection/service.rs
+++ b/crates/nvisy-server/src/service/detection/service.rs
@@ -61,7 +61,7 @@ impl DetectionService {
     pub async fn subscribe_status(
         &self,
         run_id: Uuid,
-    ) -> Result<impl futures::Stream<Item = RunStatusEvent> + Send> {
+    ) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = RunStatusEvent> + Send>>> {
         let stream = self
             .nats
             .subscribe_broadcast::<RunStatusEvent>(run_subject(run_id))

--- a/crates/nvisy-server/src/service/detection/support.rs
+++ b/crates/nvisy-server/src/service/detection/support.rs
@@ -1,0 +1,76 @@
+//! Shared detection helpers used by both the create-run handler and the worker.
+
+use nvisy_engine::policy::PolicyDefinition;
+use nvisy_postgres::model::UpdateWorkspacePipelineRun;
+use nvisy_postgres::query::{
+    PipelineReferenceRepository, WorkspacePipelineRunRepository, WorkspacePolicyRepository,
+};
+use nvisy_postgres::types::PipelineRunStatus;
+use uuid::Uuid;
+
+use super::service::DetectionService;
+use crate::handler::Result;
+use crate::service::{CryptoService, WebhookEmitter};
+
+/// Tracing target for shared detection operations.
+const TRACING_TARGET: &str = "nvisy_server::service::detection";
+
+/// Marks a run `Failed` (best effort), recording `reason` in its metadata,
+/// broadcasting the terminal status for SSE watchers, and emitting the
+/// `pipeline:run.failed` webhook event.
+///
+/// Shared by the create-run handler (enqueue failed) and the worker (analysis
+/// failed) so a failure takes the same three steps on every path.
+pub(crate) async fn fail_run(
+    conn: &mut nvisy_postgres::PgConn,
+    detection: &DetectionService,
+    webhook_emitter: &WebhookEmitter,
+    workspace_id: Uuid,
+    run_id: Uuid,
+    triggered_by: Uuid,
+    reason: &str,
+) {
+    let update = UpdateWorkspacePipelineRun {
+        status: Some(PipelineRunStatus::Failed),
+        metadata: Some(serde_json::json!({ "error": reason })),
+        completed_at: Some(Some(jiff::Timestamp::now().into())),
+        ..Default::default()
+    };
+    if let Err(err) = conn.update_workspace_pipeline_run(run_id, update).await {
+        tracing::warn!(target: TRACING_TARGET, error = %err, %run_id, "Failed to mark run failed");
+    }
+
+    detection
+        .broadcast_status(run_id, PipelineRunStatus::Failed)
+        .await;
+
+    if let Err(err) = webhook_emitter
+        .emit_pipeline_run_failed(workspace_id, run_id, Some(triggered_by), None)
+        .await
+    {
+        tracing::warn!(
+            target: TRACING_TARGET,
+            error = %err,
+            %run_id,
+            "Failed to emit pipeline:run.failed webhook event"
+        );
+    }
+}
+
+/// Resolves a pipeline's live policy references into decrypted engine policies.
+pub(crate) async fn resolve_policies(
+    conn: &mut nvisy_postgres::PgConn,
+    crypto: &CryptoService,
+    workspace_id: Uuid,
+    pipeline_id: Uuid,
+) -> Result<Vec<PolicyDefinition>> {
+    let ids = conn.list_pipeline_policy_ids(pipeline_id).await?;
+    let mut policies = Vec::with_capacity(ids.len());
+    for id in ids {
+        if let Some(model) = conn.find_policy_in_workspace(workspace_id, id).await? {
+            policies
+                .push(crypto.decrypt_json::<PolicyDefinition>(workspace_id, &model.definition)?);
+        }
+    }
+    Ok(policies)
+}

--- a/crates/nvisy-server/src/service/detection/worker.rs
+++ b/crates/nvisy-server/src/service/detection/worker.rs
@@ -22,7 +22,8 @@ use nvisy_postgres::{PgClient, PgConn};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-use super::job::{DetectionJob, RunStatusEvent, run_subject};
+use super::job::DetectionJob;
+use super::service::DetectionService;
 use crate::handler::request::PipelineDefinition;
 use crate::handler::{ErrorKind, Result};
 use crate::service::{BlobService, CryptoService, EngineService, WebhookEmitter};
@@ -38,6 +39,7 @@ pub struct DetectionWorker {
     engine: EngineService,
     blob: BlobService,
     webhook_emitter: WebhookEmitter,
+    detection: DetectionService,
 }
 
 impl DetectionWorker {
@@ -49,6 +51,7 @@ impl DetectionWorker {
         engine: EngineService,
         blob: BlobService,
         webhook_emitter: WebhookEmitter,
+        detection: DetectionService,
     ) -> Self {
         Self {
             postgres,
@@ -57,6 +60,7 @@ impl DetectionWorker {
             engine,
             blob,
             webhook_emitter,
+            detection,
         }
     }
 
@@ -202,7 +206,9 @@ impl DetectionWorker {
         .await?;
 
         tracing::info!(target: TRACING_TARGET, run_id = %run.id, "Run analyzed");
-        self.broadcast_status(run.id, PipelineRunStatus::Analyzed).await;
+        self.detection
+            .broadcast_status(run.id, PipelineRunStatus::Analyzed)
+            .await;
 
         if let Err(err) = self
             .webhook_emitter
@@ -226,7 +232,9 @@ impl DetectionWorker {
             tracing::warn!(target: TRACING_TARGET, error = %err, "Failed to mark run failed");
         }
 
-        self.broadcast_status(run.id, PipelineRunStatus::Failed).await;
+        self.detection
+            .broadcast_status(run.id, PipelineRunStatus::Failed)
+            .await;
 
         if let Err(err) = self
             .webhook_emitter
@@ -234,14 +242,6 @@ impl DetectionWorker {
             .await
         {
             tracing::warn!(target: TRACING_TARGET, error = %err, "Failed to emit pipeline:run.failed webhook event");
-        }
-    }
-
-    /// Broadcasts a run's status change on its core-NATS subject (best-effort).
-    async fn broadcast_status(&self, run_id: Uuid, status: PipelineRunStatus) {
-        let event = RunStatusEvent { run_id, status };
-        if let Err(err) = self.nats.publish_broadcast(run_subject(run_id), &event).await {
-            tracing::debug!(target: TRACING_TARGET, error = %err, "Failed to broadcast run status");
         }
     }
 }

--- a/crates/nvisy-server/src/service/detection/worker.rs
+++ b/crates/nvisy-server/src/service/detection/worker.rs
@@ -1,0 +1,273 @@
+//! Pipeline detection worker.
+//!
+//! Consumes [`DetectionJob`]s from the `DetectionStream` work-queue and runs a
+//! run's detection (analyze) in the background: builds the document, analyzes it
+//! with the pipeline's policies, stores the encrypted audit, and marks the run
+//! `Analyzed` (or `Failed`). Each terminal transition is broadcast on the run's
+//! core-NATS status subject (for SSE watchers) and emitted as a webhook event.
+
+use std::time::Duration;
+
+use nvisy_engine::policy::PolicyDefinition;
+use nvisy_nats::NatsClient;
+use nvisy_nats::stream::DetectionStream;
+use nvisy_postgres::model::{UpdateWorkspacePipelineRun, WorkspacePipeline, WorkspacePipelineRun};
+use nvisy_postgres::query::{
+    PipelineReferenceRepository, WorkspaceFileRepository, WorkspacePipelineRunRepository,
+    WorkspacePolicyRepository, WorkspaceRepository,
+};
+use nvisy_engine::OcrMode;
+use nvisy_postgres::types::{OcrPolicy, PipelineRunStatus, WorkspaceSettings};
+use nvisy_postgres::{PgClient, PgConn};
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use super::job::{DetectionJob, RunStatusEvent, run_subject};
+use crate::handler::request::PipelineDefinition;
+use crate::handler::{ErrorKind, Result};
+use crate::service::{BlobService, CryptoService, EngineService, WebhookEmitter};
+
+/// Tracing target for detection worker operations.
+const TRACING_TARGET: &str = "nvisy_server::worker::detection";
+
+/// Background worker that runs pipeline detection off the request thread.
+pub struct DetectionWorker {
+    postgres: PgClient,
+    nats: NatsClient,
+    crypto: CryptoService,
+    engine: EngineService,
+    blob: BlobService,
+    webhook_emitter: WebhookEmitter,
+}
+
+impl DetectionWorker {
+    /// Creates a new [`DetectionWorker`].
+    pub fn new(
+        postgres: PgClient,
+        nats: NatsClient,
+        crypto: CryptoService,
+        engine: EngineService,
+        blob: BlobService,
+        webhook_emitter: WebhookEmitter,
+    ) -> Self {
+        Self {
+            postgres,
+            nats,
+            crypto,
+            engine,
+            blob,
+            webhook_emitter,
+        }
+    }
+
+    /// Runs the worker until cancelled, logging its lifecycle.
+    pub async fn run(&self, cancel: CancellationToken) -> Result<()> {
+        tracing::info!(target: TRACING_TARGET, "Starting detection worker");
+
+        let result = self.run_inner(cancel).await;
+
+        match &result {
+            Ok(()) => tracing::info!(target: TRACING_TARGET, "Detection worker stopped"),
+            Err(err) => {
+                tracing::error!(target: TRACING_TARGET, error = %err, "Detection worker failed")
+            }
+        }
+
+        result
+    }
+
+    /// Consumes detection jobs until cancelled. At-least-once: run first, then
+    /// ack; a crash before ack redelivers, and the job is idempotent (a run no
+    /// longer `Running` is skipped).
+    async fn run_inner(&self, cancel: CancellationToken) -> Result<()> {
+        let subscriber = self.nats.event_subscriber::<DetectionJob, DetectionStream>().await?;
+        let mut stream = subscriber.subscribe().await?;
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    tracing::info!(target: TRACING_TARGET, "Detection worker shutdown requested");
+                    break;
+                }
+                result = stream.next_with_timeout(Duration::from_secs(5)) => {
+                    match result {
+                        Ok(Some(mut message)) => {
+                            let job = message.payload().clone();
+                            self.run_job(job).await;
+                            if let Err(err) = message.ack().await {
+                                tracing::error!(target: TRACING_TARGET, error = %err, "Failed to ack detection job");
+                            }
+                        }
+                        Ok(None) => {}
+                        Err(err) => {
+                            tracing::error!(target: TRACING_TARGET, error = %err, "Error receiving detection job");
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Runs one detection job: loads the run, analyzes, and records the result.
+    #[tracing::instrument(skip_all, fields(run_id = %job.run_id, workspace_id = %job.workspace_id))]
+    async fn run_job(&self, job: DetectionJob) {
+        let mut conn = match self.postgres.get_connection().await {
+            Ok(conn) => conn,
+            Err(err) => {
+                tracing::error!(target: TRACING_TARGET, error = %err, "Failed to get connection for detection job");
+                return;
+            }
+        };
+
+        let (run, pipeline) = match conn.find_workspace_run_by_id(job.workspace_id, job.run_id).await {
+            Ok(Some(pair)) => pair,
+            Ok(None) => {
+                tracing::warn!(target: TRACING_TARGET, "Detection job for a missing run; skipping");
+                return;
+            }
+            Err(err) => {
+                tracing::error!(target: TRACING_TARGET, error = %err, "Failed to load run for detection job");
+                return;
+            }
+        };
+
+        // Idempotent redelivery: only a still-`Running` run is analyzed.
+        if run.status != PipelineRunStatus::Running {
+            tracing::debug!(target: TRACING_TARGET, status = %run.status, "Run is not running; skipping detection");
+            return;
+        }
+
+        if let Err(err) = self.detect(&mut conn, &job, &run, &pipeline).await {
+            tracing::warn!(target: TRACING_TARGET, error = %err, "Detection failed");
+            self.mark_failed(&mut conn, &job, &run).await;
+        }
+    }
+
+    /// Performs the analysis and records the run as `Analyzed`.
+    async fn detect(
+        &self,
+        conn: &mut PgConn,
+        job: &DetectionJob,
+        run: &WorkspacePipelineRun,
+        pipeline: &WorkspacePipeline,
+    ) -> Result<()> {
+        let workspace = conn
+            .find_workspace_by_id(job.workspace_id)
+            .await?
+            .ok_or_else(|| ErrorKind::NotFound.with_message("Workspace not found"))?;
+        let file = conn
+            .find_file_in_workspace(job.workspace_id, run.input_file_id)
+            .await?
+            .ok_or_else(|| ErrorKind::NotFound.with_message("Input file not found"))?;
+
+        let definition = PipelineDefinition::from_parts(pipeline.definition.clone(), Vec::new())
+            .map_err(|err| {
+                ErrorKind::InternalServerError
+                    .with_message("Failed to decode pipeline definition")
+                    .with_context(err.to_string())
+            })?;
+
+        let ocr_mode = ocr_mode_of(&workspace.settings);
+        let params = self
+            .engine
+            .analyzer_params(&definition, job.scope.clone(), ocr_mode);
+
+        let document = self.blob.build_document(&file, run.id).await?;
+
+        let policies = resolve_policies(conn, &self.crypto, job.workspace_id, pipeline.id).await?;
+        if policies.is_empty() {
+            return Err(ErrorKind::BadRequest
+                .with_message("Pipeline has no policies")
+                .with_resource("pipeline"));
+        }
+
+        let analyzed = self.engine.analyze(document, &policies, &params).await?;
+
+        let retention = WorkspaceSettings::from_value(&workspace.settings).retention;
+        let audit_file_id = self
+            .blob
+            .store_analyzed_document(conn, pipeline, &retention, run.account_id, &analyzed)
+            .await?;
+
+        conn.update_workspace_pipeline_run(
+            run.id,
+            UpdateWorkspacePipelineRun {
+                status: Some(PipelineRunStatus::Analyzed),
+                audit_file_id: Some(Some(audit_file_id)),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        tracing::info!(target: TRACING_TARGET, run_id = %run.id, "Run analyzed");
+        self.broadcast_status(run.id, PipelineRunStatus::Analyzed).await;
+
+        if let Err(err) = self
+            .webhook_emitter
+            .emit_pipeline_run_analyzed(job.workspace_id, run.id, Some(run.account_id), None)
+            .await
+        {
+            tracing::warn!(target: TRACING_TARGET, error = %err, "Failed to emit pipeline:run.analyzed webhook event");
+        }
+
+        Ok(())
+    }
+
+    /// Marks a run `Failed`, broadcasts, and emits the failure webhook.
+    async fn mark_failed(&self, conn: &mut PgConn, job: &DetectionJob, run: &WorkspacePipelineRun) {
+        let update = UpdateWorkspacePipelineRun {
+            status: Some(PipelineRunStatus::Failed),
+            completed_at: Some(Some(jiff::Timestamp::now().into())),
+            ..Default::default()
+        };
+        if let Err(err) = conn.update_workspace_pipeline_run(run.id, update).await {
+            tracing::warn!(target: TRACING_TARGET, error = %err, "Failed to mark run failed");
+        }
+
+        self.broadcast_status(run.id, PipelineRunStatus::Failed).await;
+
+        if let Err(err) = self
+            .webhook_emitter
+            .emit_pipeline_run_failed(job.workspace_id, run.id, Some(run.account_id), None)
+            .await
+        {
+            tracing::warn!(target: TRACING_TARGET, error = %err, "Failed to emit pipeline:run.failed webhook event");
+        }
+    }
+
+    /// Broadcasts a run's status change on its core-NATS subject (best-effort).
+    async fn broadcast_status(&self, run_id: Uuid, status: PipelineRunStatus) {
+        let event = RunStatusEvent { run_id, status };
+        if let Err(err) = self.nats.publish_broadcast(run_subject(run_id), &event).await {
+            tracing::debug!(target: TRACING_TARGET, error = %err, "Failed to broadcast run status");
+        }
+    }
+}
+
+/// Resolves a pipeline's live policy references into decrypted engine policies.
+pub(crate) async fn resolve_policies(
+    conn: &mut PgConn,
+    crypto: &CryptoService,
+    workspace_id: Uuid,
+    pipeline_id: Uuid,
+) -> Result<Vec<PolicyDefinition>> {
+    let ids = conn.list_pipeline_policy_ids(pipeline_id).await?;
+    let mut policies = Vec::with_capacity(ids.len());
+    for id in ids {
+        if let Some(model) = conn.find_policy_in_workspace(workspace_id, id).await? {
+            policies.push(crypto.decrypt_json::<PolicyDefinition>(workspace_id, &model.definition)?);
+        }
+    }
+    Ok(policies)
+}
+
+/// Maps a workspace's OCR policy to the engine's per-run OCR mode.
+pub(crate) fn ocr_mode_of(settings: &serde_json::Value) -> OcrMode {
+    match WorkspaceSettings::from_value(settings).ocr {
+        OcrPolicy::Auto => OcrMode::Auto,
+        OcrPolicy::Force => OcrMode::force(),
+        OcrPolicy::Never => OcrMode::Never,
+    }
+}

--- a/crates/nvisy-server/src/service/detection/worker.rs
+++ b/crates/nvisy-server/src/service/detection/worker.rs
@@ -8,6 +8,7 @@
 
 use std::time::Duration;
 
+use nvisy_engine::OcrMode;
 use nvisy_engine::policy::PolicyDefinition;
 use nvisy_nats::NatsClient;
 use nvisy_nats::stream::DetectionStream;
@@ -16,7 +17,6 @@ use nvisy_postgres::query::{
     PipelineReferenceRepository, WorkspaceFileRepository, WorkspacePipelineRunRepository,
     WorkspacePolicyRepository, WorkspaceRepository,
 };
-use nvisy_engine::OcrMode;
 use nvisy_postgres::types::{OcrPolicy, PipelineRunStatus, WorkspaceSettings};
 use nvisy_postgres::{PgClient, PgConn};
 use tokio_util::sync::CancellationToken;
@@ -84,7 +84,10 @@ impl DetectionWorker {
     /// ack; a crash before ack redelivers, and the job is idempotent (a run no
     /// longer `Running` is skipped).
     async fn run_inner(&self, cancel: CancellationToken) -> Result<()> {
-        let subscriber = self.nats.event_subscriber::<DetectionJob, DetectionStream>().await?;
+        let subscriber = self
+            .nats
+            .event_subscriber::<DetectionJob, DetectionStream>()
+            .await?;
         let mut stream = subscriber.subscribe().await?;
 
         loop {
@@ -125,7 +128,10 @@ impl DetectionWorker {
             }
         };
 
-        let (run, pipeline) = match conn.find_workspace_run_by_id(job.workspace_id, job.run_id).await {
+        let (run, pipeline) = match conn
+            .find_workspace_run_by_id(job.workspace_id, job.run_id)
+            .await
+        {
             Ok(Some(pair)) => pair,
             Ok(None) => {
                 tracing::warn!(target: TRACING_TARGET, "Detection job for a missing run; skipping");
@@ -257,7 +263,8 @@ pub(crate) async fn resolve_policies(
     let mut policies = Vec::with_capacity(ids.len());
     for id in ids {
         if let Some(model) = conn.find_policy_in_workspace(workspace_id, id).await? {
-            policies.push(crypto.decrypt_json::<PolicyDefinition>(workspace_id, &model.definition)?);
+            policies
+                .push(crypto.decrypt_json::<PolicyDefinition>(workspace_id, &model.definition)?);
         }
     }
     Ok(policies)

--- a/crates/nvisy-server/src/service/detection/worker.rs
+++ b/crates/nvisy-server/src/service/detection/worker.rs
@@ -9,27 +9,31 @@
 use std::time::Duration;
 
 use nvisy_engine::OcrMode;
-use nvisy_engine::policy::PolicyDefinition;
 use nvisy_nats::NatsClient;
 use nvisy_nats::stream::DetectionStream;
 use nvisy_postgres::model::{UpdateWorkspacePipelineRun, WorkspacePipeline, WorkspacePipelineRun};
 use nvisy_postgres::query::{
-    PipelineReferenceRepository, WorkspaceFileRepository, WorkspacePipelineRunRepository,
-    WorkspacePolicyRepository, WorkspaceRepository,
+    WorkspaceFileRepository, WorkspacePipelineRunRepository, WorkspaceRepository,
 };
 use nvisy_postgres::types::{OcrPolicy, PipelineRunStatus, WorkspaceSettings};
 use nvisy_postgres::{PgClient, PgConn};
 use tokio_util::sync::CancellationToken;
-use uuid::Uuid;
 
 use super::job::DetectionJob;
 use super::service::DetectionService;
+use super::support::{fail_run, resolve_policies};
 use crate::handler::request::PipelineDefinition;
 use crate::handler::{ErrorKind, Result};
 use crate::service::{BlobService, CryptoService, EngineService, WebhookEmitter};
 
 /// Tracing target for detection worker operations.
 const TRACING_TARGET: &str = "nvisy_server::worker::detection";
+
+/// How long a detection claim stays valid before another delivery may re-claim
+/// the run. Set above `DetectionStream::ACK_WAIT` (15 min) so a slow-but-healthy
+/// worker whose job is redelivered keeps its claim; only a run whose worker died
+/// (no progress past the lease) is re-claimed and re-analyzed.
+const DETECTION_LEASE: Duration = Duration::from_secs(30 * 60);
 
 /// Background worker that runs pipeline detection off the request thread.
 pub struct DetectionWorker {
@@ -80,9 +84,14 @@ impl DetectionWorker {
         result
     }
 
-    /// Consumes detection jobs until cancelled. At-least-once: run first, then
-    /// ack; a crash before ack redelivers, and the job is idempotent (a run no
-    /// longer `Running` is skipped).
+    /// Consumes detection jobs until cancelled.
+    ///
+    /// At-least-once with an explicit claim: a job is acked once it reaches a
+    /// terminal outcome (analyzed, or marked failed), and nacked for redelivery
+    /// on a transient error (a DB/pool blip before the run could even be
+    /// claimed), so a run is never silently stranded in a non-terminal state.
+    /// The claim (`claim_run_for_detection`) makes redelivery idempotent: a run
+    /// already being analyzed under a fresh lease is skipped.
     async fn run_inner(&self, cancel: CancellationToken) -> Result<()> {
         let subscriber = self
             .nats
@@ -100,9 +109,15 @@ impl DetectionWorker {
                     match result {
                         Ok(Some(mut message)) => {
                             let job = message.payload().clone();
-                            self.run_job(job).await;
-                            if let Err(err) = message.ack().await {
-                                tracing::error!(target: TRACING_TARGET, error = %err, "Failed to ack detection job");
+                            let outcome = self.run_job(job).await;
+                            let ack_result = match outcome {
+                                JobOutcome::Done => message.ack().await,
+                                // Transient failure: redeliver instead of dropping
+                                // the job, so the run is eventually settled.
+                                JobOutcome::Retry => message.nack().await,
+                            };
+                            if let Err(err) = ack_result {
+                                tracing::error!(target: TRACING_TARGET, error = %err, ?outcome, "Failed to ack/nack detection job");
                             }
                         }
                         Ok(None) => {}
@@ -117,14 +132,21 @@ impl DetectionWorker {
         Ok(())
     }
 
-    /// Runs one detection job: loads the run, analyzes, and records the result.
+    /// Runs one detection job: claims the run, analyzes, and records the result.
+    ///
+    /// Returns [`JobOutcome::Retry`] when the job should be redelivered (a
+    /// transient error before the run was claimed), and [`JobOutcome::Done`]
+    /// when it reached a terminal outcome or is safe to drop (missing run,
+    /// already claimed, already settled).
     #[tracing::instrument(skip_all, fields(run_id = %job.run_id, workspace_id = %job.workspace_id))]
-    async fn run_job(&self, job: DetectionJob) {
+    async fn run_job(&self, job: DetectionJob) -> JobOutcome {
         let mut conn = match self.postgres.get_connection().await {
             Ok(conn) => conn,
             Err(err) => {
+                // No connection: the run is still queued. Redeliver so it is not
+                // stranded in a non-terminal state.
                 tracing::error!(target: TRACING_TARGET, error = %err, "Failed to get connection for detection job");
-                return;
+                return JobOutcome::Retry;
             }
         };
 
@@ -134,25 +156,58 @@ impl DetectionWorker {
         {
             Ok(Some(pair)) => pair,
             Ok(None) => {
-                tracing::warn!(target: TRACING_TARGET, "Detection job for a missing run; skipping");
-                return;
+                tracing::warn!(target: TRACING_TARGET, "Detection job for a missing run; dropping");
+                return JobOutcome::Done;
             }
             Err(err) => {
+                // Transient load error: redeliver rather than strand the run.
                 tracing::error!(target: TRACING_TARGET, error = %err, "Failed to load run for detection job");
-                return;
+                return JobOutcome::Retry;
             }
         };
 
-        // Idempotent redelivery: only a still-`Running` run is analyzed.
-        if run.status != PipelineRunStatus::Running {
-            tracing::debug!(target: TRACING_TARGET, status = %run.status, "Run is not running; skipping detection");
-            return;
+        // Nothing to do for a run already past the queued/analyzing phase.
+        if !run.status.is_detecting() {
+            tracing::debug!(target: TRACING_TARGET, status = %run.status, "Run is not detecting; dropping");
+            return JobOutcome::Done;
         }
+
+        // Atomically claim the run (queued -> analyzing). A redelivery whose
+        // claim is still fresh matches no row and is skipped, so a slow job is
+        // never analyzed twice; only a run whose worker died (stale lease) is
+        // re-claimed.
+        let stale_before = jiff::Timestamp::now() - DETECTION_LEASE;
+        let claimed = match conn.claim_run_for_detection(run.id, stale_before).await {
+            Ok(Some(_)) => true,
+            Ok(None) => {
+                tracing::debug!(target: TRACING_TARGET, "Run already claimed by another worker; skipping");
+                return JobOutcome::Done;
+            }
+            Err(err) => {
+                tracing::error!(target: TRACING_TARGET, error = %err, "Failed to claim run for detection");
+                return JobOutcome::Retry;
+            }
+        };
+        debug_assert!(claimed);
+
+        self.detection
+            .broadcast_status(run.id, PipelineRunStatus::Analyzing)
+            .await;
 
         if let Err(err) = self.detect(&mut conn, &job, &run, &pipeline).await {
             tracing::warn!(target: TRACING_TARGET, error = %err, "Detection failed");
-            self.mark_failed(&mut conn, &job, &run).await;
+            fail_run(
+                &mut conn,
+                &self.detection,
+                &self.webhook_emitter,
+                job.workspace_id,
+                run.id,
+                run.account_id,
+                &err.to_string(),
+            )
+            .await;
         }
+        JobOutcome::Done
     }
 
     /// Performs the analysis and records the run as `Analyzed`.
@@ -179,10 +234,11 @@ impl DetectionWorker {
                     .with_context(err.to_string())
             })?;
 
-        let ocr_mode = ocr_mode_of(&workspace.settings);
-        let params = self
-            .engine
-            .analyzer_params(&definition, job.scope.clone(), ocr_mode);
+        // Parse the workspace settings once; both OCR mode and retention read it.
+        let settings = WorkspaceSettings::from_value(&workspace.settings);
+        let params =
+            self.engine
+                .analyzer_params(&definition, job.scope.clone(), ocr_mode_of(&settings));
 
         let document = self.blob.build_document(&file, run.id).await?;
 
@@ -195,10 +251,15 @@ impl DetectionWorker {
 
         let analyzed = self.engine.analyze(document, &policies, &params).await?;
 
-        let retention = WorkspaceSettings::from_value(&workspace.settings).retention;
         let audit_file_id = self
             .blob
-            .store_analyzed_document(conn, pipeline, &retention, run.account_id, &analyzed)
+            .store_analyzed_document(
+                conn,
+                pipeline,
+                &settings.retention,
+                run.account_id,
+                &analyzed,
+            )
             .await?;
 
         conn.update_workspace_pipeline_run(
@@ -226,53 +287,20 @@ impl DetectionWorker {
 
         Ok(())
     }
-
-    /// Marks a run `Failed`, broadcasts, and emits the failure webhook.
-    async fn mark_failed(&self, conn: &mut PgConn, job: &DetectionJob, run: &WorkspacePipelineRun) {
-        let update = UpdateWorkspacePipelineRun {
-            status: Some(PipelineRunStatus::Failed),
-            completed_at: Some(Some(jiff::Timestamp::now().into())),
-            ..Default::default()
-        };
-        if let Err(err) = conn.update_workspace_pipeline_run(run.id, update).await {
-            tracing::warn!(target: TRACING_TARGET, error = %err, "Failed to mark run failed");
-        }
-
-        self.detection
-            .broadcast_status(run.id, PipelineRunStatus::Failed)
-            .await;
-
-        if let Err(err) = self
-            .webhook_emitter
-            .emit_pipeline_run_failed(job.workspace_id, run.id, Some(run.account_id), None)
-            .await
-        {
-            tracing::warn!(target: TRACING_TARGET, error = %err, "Failed to emit pipeline:run.failed webhook event");
-        }
-    }
 }
 
-/// Resolves a pipeline's live policy references into decrypted engine policies.
-pub(crate) async fn resolve_policies(
-    conn: &mut PgConn,
-    crypto: &CryptoService,
-    workspace_id: Uuid,
-    pipeline_id: Uuid,
-) -> Result<Vec<PolicyDefinition>> {
-    let ids = conn.list_pipeline_policy_ids(pipeline_id).await?;
-    let mut policies = Vec::with_capacity(ids.len());
-    for id in ids {
-        if let Some(model) = conn.find_policy_in_workspace(workspace_id, id).await? {
-            policies
-                .push(crypto.decrypt_json::<PolicyDefinition>(workspace_id, &model.definition)?);
-        }
-    }
-    Ok(policies)
+/// Whether a consumed detection job should be acked (done) or nacked (retry).
+#[derive(Debug, Clone, Copy)]
+enum JobOutcome {
+    /// Reached a terminal outcome or is safe to drop; ack the message.
+    Done,
+    /// Transient error before the run was claimed; nack for redelivery.
+    Retry,
 }
 
 /// Maps a workspace's OCR policy to the engine's per-run OCR mode.
-pub(crate) fn ocr_mode_of(settings: &serde_json::Value) -> OcrMode {
-    match WorkspaceSettings::from_value(settings).ocr {
+fn ocr_mode_of(settings: &WorkspaceSettings) -> OcrMode {
+    match settings.ocr {
         OcrPolicy::Auto => OcrMode::Auto,
         OcrPolicy::Force => OcrMode::force(),
         OcrPolicy::Never => OcrMode::Never,

--- a/crates/nvisy-server/src/service/mod.rs
+++ b/crates/nvisy-server/src/service/mod.rs
@@ -28,6 +28,7 @@ pub(crate) use crate::service::crypto::{HashingReader, Measurements};
 pub use crate::service::detection::{
     DetectionJob, DetectionService, DetectionWorker, RunStatusEvent, run_subject,
 };
+pub(crate) use crate::service::detection::{fail_run, resolve_policies};
 pub use crate::service::engine::{EngineConfig, EngineService, UnknownFormatToken};
 pub use crate::service::health::{HealthCache, HealthConfig};
 pub use crate::service::object::ObjectService;

--- a/crates/nvisy-server/src/service/mod.rs
+++ b/crates/nvisy-server/src/service/mod.rs
@@ -2,6 +2,7 @@
 
 mod avatar;
 mod blob;
+mod detection;
 mod connection;
 pub mod crypto;
 pub mod engine;
@@ -21,6 +22,7 @@ use nvisy_webhook::WebhookService;
 
 pub use crate::service::avatar::{AVATAR_CONTENT_TYPE, AvatarService, MAX_AVATAR_UPLOAD_BYTES};
 pub use crate::service::blob::BlobService;
+pub use crate::service::detection::{DetectionJob, DetectionWorker, RunStatusEvent, run_subject};
 pub use crate::service::connection::ConnectionConfig;
 pub use crate::service::crypto::{CryptoConfig, CryptoService};
 pub(crate) use crate::service::crypto::{HashingReader, Measurements};

--- a/crates/nvisy-server/src/service/mod.rs
+++ b/crates/nvisy-server/src/service/mod.rs
@@ -22,12 +22,12 @@ use nvisy_webhook::WebhookService;
 
 pub use crate::service::avatar::{AVATAR_CONTENT_TYPE, AvatarService, MAX_AVATAR_UPLOAD_BYTES};
 pub use crate::service::blob::BlobService;
-pub use crate::service::detection::{
-    DetectionJob, DetectionService, DetectionWorker, RunStatusEvent, run_subject,
-};
 pub use crate::service::connection::ConnectionConfig;
 pub use crate::service::crypto::{CryptoConfig, CryptoService};
 pub(crate) use crate::service::crypto::{HashingReader, Measurements};
+pub use crate::service::detection::{
+    DetectionJob, DetectionService, DetectionWorker, RunStatusEvent, run_subject,
+};
 pub use crate::service::engine::{EngineConfig, EngineService, UnknownFormatToken};
 pub use crate::service::health::{HealthCache, HealthConfig};
 pub use crate::service::object::ObjectService;

--- a/crates/nvisy-server/src/service/mod.rs
+++ b/crates/nvisy-server/src/service/mod.rs
@@ -2,9 +2,9 @@
 
 mod avatar;
 mod blob;
-mod detection;
 mod connection;
 pub mod crypto;
+mod detection;
 pub mod engine;
 mod health;
 mod object;
@@ -22,7 +22,9 @@ use nvisy_webhook::WebhookService;
 
 pub use crate::service::avatar::{AVATAR_CONTENT_TYPE, AvatarService, MAX_AVATAR_UPLOAD_BYTES};
 pub use crate::service::blob::BlobService;
-pub use crate::service::detection::{DetectionJob, DetectionWorker, RunStatusEvent, run_subject};
+pub use crate::service::detection::{
+    DetectionJob, DetectionService, DetectionWorker, RunStatusEvent, run_subject,
+};
 pub use crate::service::connection::ConnectionConfig;
 pub use crate::service::crypto::{CryptoConfig, CryptoService};
 pub(crate) use crate::service::crypto::{HashingReader, Measurements};
@@ -62,6 +64,7 @@ pub struct ServiceState {
     // Internal services:
     pub avatar: AvatarService,
     pub blob: BlobService,
+    pub detection: DetectionService,
     pub connection_sync: ConnectionSyncService,
     pub health_cache: HealthCache,
     pub object: ObjectService,
@@ -101,6 +104,7 @@ impl ServiceState {
 
         let object = ObjectService::new();
         let blob = BlobService::new(nats_client.clone(), crypto.clone());
+        let detection = DetectionService::new(nats_client.clone());
         let avatar = AvatarService::new(nats_client.clone(), postgres_client.clone());
         let connection_sync = ConnectionSyncService::new(
             postgres_client.clone(),
@@ -121,6 +125,7 @@ impl ServiceState {
 
             avatar,
             blob,
+            detection,
             connection_sync,
             health_cache: HealthCache::new(&health_config, health_checkers),
             object,
@@ -156,6 +161,19 @@ impl ServiceState {
     /// Builds the data-retention worker from this state.
     pub fn retention_worker(&self) -> RetentionWorker {
         RetentionWorker::new(self.postgres.clone(), self.nats.clone())
+    }
+
+    /// Builds the pipeline detection worker from this state.
+    pub fn detection_worker(&self) -> DetectionWorker {
+        DetectionWorker::new(
+            self.postgres.clone(),
+            self.nats.clone(),
+            self.crypto.clone(),
+            self.engine.clone(),
+            self.blob.clone(),
+            self.webhook_emitter.clone(),
+            self.detection.clone(),
+        )
     }
 }
 
@@ -200,6 +218,7 @@ impl_di!(
 impl_di!(
     avatar: AvatarService,
     blob: BlobService,
+    detection: DetectionService,
     connection_sync: ConnectionSyncService,
     crypto: CryptoService,
     engine: EngineService,

--- a/crates/nvisy-server/src/service/webhook/emitter.rs
+++ b/crates/nvisy-server/src/service/webhook/emitter.rs
@@ -75,6 +75,7 @@ impl WebhookEmitter {
         emit_pipeline_updated => PipelineUpdated,
         emit_pipeline_deleted => PipelineDeleted,
         emit_pipeline_run_started => PipelineRunStarted,
+        emit_pipeline_run_analyzed => PipelineRunAnalyzed,
         emit_pipeline_run_completed => PipelineRunCompleted,
         emit_pipeline_run_failed => PipelineRunFailed,
         emit_policy_created => PolicyCreated,

--- a/migrations/2025-05-21-222842_webhooks/up.sql
+++ b/migrations/2025-05-21-222842_webhooks/up.sql
@@ -36,6 +36,7 @@ CREATE TYPE WEBHOOK_EVENT AS ENUM (
     'pipeline:updated',
     'pipeline:deleted',
     'pipeline:run.started',
+    'pipeline:run.analyzed',
     'pipeline:run.completed',
     'pipeline:run.failed',
 

--- a/migrations/2026-01-19-045014_pipelines/up.sql
+++ b/migrations/2026-01-19-045014_pipelines/up.sql
@@ -13,7 +13,8 @@ COMMENT ON TYPE PIPELINE_STATUS IS
 
 -- Pipeline run status enum
 CREATE TYPE PIPELINE_RUN_STATUS AS ENUM (
-    'running',      -- Detection in progress
+    'queued',       -- Enqueued for detection; no worker has picked it up yet
+    'analyzing',    -- A worker is actively analyzing the document
     'analyzed',     -- Detection done; awaiting reviewer verification
     'completed',    -- Redaction applied; run finished
     'failed',       -- Run failed with error
@@ -158,7 +159,7 @@ CREATE TABLE workspace_pipeline_runs (
 
     -- Run attributes
     trigger_type    PIPELINE_TRIGGER_TYPE   NOT NULL DEFAULT 'user',
-    status          PIPELINE_RUN_STATUS     NOT NULL DEFAULT 'running',
+    status          PIPELINE_RUN_STATUS     NOT NULL DEFAULT 'queued',
 
     -- Idempotency key from the initiating detect request; a repeat replays the
     -- existing run instead of analyzing twice.
@@ -170,6 +171,11 @@ CREATE TABLE workspace_pipeline_runs (
     metadata        JSONB                   NOT NULL DEFAULT '{}',
 
     CONSTRAINT workspace_pipeline_runs_metadata_size CHECK (length(metadata::TEXT) BETWEEN 2 AND 65536),
+
+    -- Detection lease: when a worker last claimed this run. A redelivered job
+    -- whose claim is still fresh is skipped (no double-analyze); a stale claim
+    -- (a worker that died mid-analysis) can be re-claimed. Null until claimed.
+    claimed_at      TIMESTAMPTZ             DEFAULT NULL,
 
     -- Timing
     started_at      TIMESTAMPTZ             NOT NULL DEFAULT current_timestamp,
@@ -187,7 +193,7 @@ CREATE INDEX workspace_pipeline_runs_account_idx
 
 CREATE INDEX workspace_pipeline_runs_status_idx
     ON workspace_pipeline_runs (status, started_at DESC)
-    WHERE status IN ('running', 'analyzed');
+    WHERE status IN ('queued', 'analyzing', 'analyzed');
 
 CREATE INDEX workspace_pipeline_runs_input_file_idx
     ON workspace_pipeline_runs (input_file_id, started_at DESC);
@@ -211,6 +217,7 @@ COMMENT ON COLUMN workspace_pipeline_runs.trigger_type IS 'How the run was initi
 COMMENT ON COLUMN workspace_pipeline_runs.status IS 'Current run status';
 COMMENT ON COLUMN workspace_pipeline_runs.idempotency_key IS 'Detect idempotency key (dedupes retries)';
 COMMENT ON COLUMN workspace_pipeline_runs.metadata IS 'Non-encrypted metadata for filtering/display';
+COMMENT ON COLUMN workspace_pipeline_runs.claimed_at IS 'Detection lease: when a worker last claimed this run';
 COMMENT ON COLUMN workspace_pipeline_runs.started_at IS 'When the run started';
 COMMENT ON COLUMN workspace_pipeline_runs.completed_at IS 'When the run completed';
 
@@ -228,7 +235,7 @@ SELECT
     EXTRACT(EPOCH FROM (COALESCE(pr.completed_at, current_timestamp) - pr.started_at)) AS duration_seconds
 FROM workspace_pipeline_runs pr
     JOIN workspace_pipelines p ON pr.pipeline_id = p.id
-WHERE pr.status IN ('running', 'analyzed')
+WHERE pr.status IN ('queued', 'analyzing', 'analyzed')
 ORDER BY pr.started_at DESC NULLS LAST;
 
 COMMENT ON VIEW active_workspace_pipeline_runs IS


### PR DESCRIPTION
## Summary

Makes pipeline detection **asynchronous**. `POST .../runs/` now creates the run, enqueues detection to a NATS work-queue, and returns **202** immediately; a background `DetectionWorker` analyzes off the request thread. Clients watch progress via a new **SSE** stream at `.../runs/{runId}/events` (Bearer-authed, `fetch`-based) or by re-reading the run, and detection completion fires a new `pipeline:run.analyzed` webhook.

This replaces the previous synchronous handler that blocked on `engine.analyze` inside the POST.

## Run lifecycle

The in-progress detect phase is split into two states so "waiting in queue" and "actively analyzing" are distinct:

`Queued → Analyzing → Analyzed → Completed` (plus `Failed` / `Cancelled`).

The worker **atomically claims** a run (`Queued → Analyzing`) via `claim_run_for_detection`, backed by a `claimed_at` lease. A job redelivered past `ACK_WAIT` (15 min) whose claim is still fresh (< 30 min lease) is skipped — so a slow job is never analyzed twice — while a run whose worker died (stale lease) is re-claimed and recovered.

## Robustness (from code review)

- **No stuck runs** — transient DB/pool errors before the run is claimed `nack` for redelivery instead of acking and stranding the run in a non-terminal state.
- **Poison messages dropped** — `TypedMessageStream::next` terminates an undeserializable message rather than leaving it un-acked to redeliver until it ages out (benefits all workers).
- **SSE can't hang** — the handler subscribes *before* reading run status (no lost terminal broadcast in the read→subscribe gap), and re-reads the authoritative run row on a poll timeout so a dropped best-effort core-NATS broadcast never leaves the stream hanging.
- **Fail fast** — an undecodable pipeline definition returns **400** synchronously instead of 202-then-async-fail.
- **Failure surfacing** — a shared `fail_run` records the reason in `run.metadata.error` (exposed as the run response's `error` field) and broadcasts `Failed` on every path, including enqueue failure.

## Notable

- New `BroadcastStream<T>` (named `Stream` over a core-NATS subscription) and `SseResponse<S>` (OpenAPI-documented SSE wrapper via aide `OperationOutput`).
- Shared `detection/support.rs` (`fail_run`, `resolve_policies`) used by both handler and worker; `WorkspaceSettings` parsed once per job.
- Migrations edited in place (pre-launch convention): `pipeline_run_status` gains `queued`/`analyzing` + `claimed_at` column; `webhook_event` gains `pipeline:run.analyzed`.
- Makefile: `clear-migrations` now aborts on a failed revert instead of looping forever on an unrevertable migration.

## Behavior change

`POST .../runs/` returns **202 (Accepted, run `queued`)** instead of the old synchronous **201-with-findings**. Follow-up issue #219 tracks configurable retryability of failed detections.

## Testing

Full gate green: `cargo check` · `fmt --check` · `clippy -D warnings` · `doc -D warnings` · `test` (0 failures). No automated test yet exercises the end-to-end async path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)