### PR TITLE
Accept status on pipeline creation

### DIFF
--- a/crates/nvisy-server/src/handler/request/pipelines.rs
+++ b/crates/nvisy-server/src/handler/request/pipelines.rs
@@ -96,6 +96,9 @@ pub struct CreatePipeline {
     /// definition that can be filled in via update.
     #[validate(nested)]
     pub definition: Option<PipelineDefinition>,
+    /// Optional lifecycle status. Defaults to `draft`; pass `enabled` to create a
+    /// pipeline ready to run without a follow-up update.
+    pub status: Option<PipelineStatus>,
     /// Optional per-scope data-retention override for this pipeline. Each unset
     /// scope inherits the workspace retention.
     pub retention: Option<RetentionOverride>,
@@ -136,7 +139,7 @@ impl CreatePipeline {
             slug: self.slug,
             display_name: self.display_name,
             description: self.description,
-            status: None,
+            status: self.status,
             definition: Some(definition),
             metadata,
             schedule_cron: None,


### PR DESCRIPTION
## Summary

`CreatePipeline` silently dropped `status`: `into_parts` hardcoded `status: None`, so a newly created pipeline always fell to the DB default (`draft`) and needed a follow-up `PATCH` to become `enabled`. `CreateWebhook` already accepts `status`, so this was an inconsistency.

Adds an optional `status: Option<PipelineStatus>` to `CreatePipeline` and threads it through `into_parts`. Omitting it keeps the `draft` default (no behavior change for existing callers); passing `enabled` creates a ready-to-run pipeline in one call.

All three `PipelineStatus` values (`draft`, `enabled`, `disabled`) are user-controlled — there's no system-only variant — so accepting it on create is safe and symmetric with `UpdatePipeline`.

## Audit

Swept every Create/Update request DTO pair for the same silent-drop; this was the only real gap. connections / webhooks / workspaces are already symmetric and correctly threaded; `tokens.expires_in` is intentionally create-only; policies have no lifecycle field.

## Testing

Full gate green (check / fmt / clippy / doc / test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)