### PR TITLE
Add filters to the run-list endpoints

### DIFF
--- a/crates/nvisy-postgres/src/query/workspace_pipeline_run.rs
+++ b/crates/nvisy-postgres/src/query/workspace_pipeline_run.rs
@@ -10,7 +10,8 @@ use crate::model::{
     NewWorkspacePipelineRun, UpdateWorkspacePipelineRun, WorkspacePipeline, WorkspacePipelineRun,
 };
 use crate::types::{
-    AccountRefRow, CursorPage, CursorPagination, Handle, PipelineRunStatus, WithAccountRef,
+    AccountRefRow, CursorPage, CursorPagination, Handle, PipelineRunStatus, RunFilter,
+    WithAccountRef,
 };
 use crate::{PgConnection, PgError, PgResult, schema};
 
@@ -44,28 +45,29 @@ pub trait WorkspacePipelineRunRepository {
         idempotency_key: &str,
     ) -> impl Future<Output = PgResult<Option<WorkspacePipelineRun>>> + Send;
 
-    /// Lists all runs for a specific pipeline with cursor pagination, each
-    /// paired with the account that triggered it.
+    /// Lists a specific pipeline's runs with cursor pagination, each paired with
+    /// the account that triggered it. `filter` narrows by status and/or file
+    /// (its `pipeline_id` is ignored — the listing is already pipeline-scoped).
     fn cursor_list_workspace_pipeline_runs(
         &mut self,
         pipeline_id: Uuid,
         pagination: CursorPagination,
-        status_filter: Option<PipelineRunStatus>,
+        filter: &RunFilter,
     ) -> impl Future<Output = PgResult<CursorPage<WithAccountRef<WorkspacePipelineRun>>>> + Send;
 
     /// Lists all runs across a workspace's pipelines with cursor pagination.
     ///
     /// Runs carry no workspace reference of their own, so this joins through the
-    /// owning pipeline and filters on its workspace. An optional status filter
-    /// narrows the result; use [`cursor_list_workspace_pipeline_runs`] for a
-    /// single pipeline.
+    /// owning pipeline and filters on its workspace. `filter` narrows by status,
+    /// file, and/or owning pipeline; use [`cursor_list_workspace_pipeline_runs`]
+    /// for a single pipeline.
     ///
     /// [`cursor_list_workspace_pipeline_runs`]: Self::cursor_list_workspace_pipeline_runs
     fn cursor_list_workspace_runs(
         &mut self,
         workspace_id: Uuid,
         pagination: CursorPagination,
-        status_filter: Option<PipelineRunStatus>,
+        filter: &RunFilter,
     ) -> impl Future<Output = PgResult<CursorPage<(WithAccountRef<WorkspacePipelineRun>, Handle)>>> + Send;
 
     /// Atomically claims a run for detection, transitioning it to `Analyzing`.
@@ -172,18 +174,28 @@ impl WorkspacePipelineRunRepository for PgConnection {
         &mut self,
         pipeline_id: Uuid,
         pagination: CursorPagination,
-        status_filter: Option<PipelineRunStatus>,
+        filter: &RunFilter,
     ) -> PgResult<CursorPage<WithAccountRef<WorkspacePipelineRun>>> {
         use schema::workspace_pipeline_runs::dsl;
         use schema::{accounts, workspace_pipeline_runs};
 
-        // Build base query with filters
+        // Build base query with filters. The listing is already scoped to one
+        // pipeline, so `filter.pipeline_id` is not applied here.
         let mut base_query = workspace_pipeline_runs::table
             .filter(dsl::pipeline_id.eq(pipeline_id))
             .into_boxed();
 
-        if let Some(status) = status_filter {
+        if let Some(status) = filter.status {
             base_query = base_query.filter(dsl::status.eq(status));
+        }
+        if let Some(file_id) = filter.input_file_id {
+            base_query = base_query.filter(dsl::input_file_id.eq(file_id));
+        }
+        if let Some(account_id) = filter.account_id {
+            base_query = base_query.filter(dsl::account_id.eq(account_id));
+        }
+        if let Some(trigger_type) = filter.trigger_type {
+            base_query = base_query.filter(dsl::trigger_type.eq(trigger_type));
         }
 
         let total = if pagination.include_count {
@@ -204,8 +216,17 @@ impl WorkspacePipelineRunRepository for PgConnection {
             .filter(dsl::pipeline_id.eq(pipeline_id))
             .into_boxed();
 
-        if let Some(status) = status_filter {
+        if let Some(status) = filter.status {
             query = query.filter(dsl::status.eq(status));
+        }
+        if let Some(file_id) = filter.input_file_id {
+            query = query.filter(dsl::input_file_id.eq(file_id));
+        }
+        if let Some(account_id) = filter.account_id {
+            query = query.filter(dsl::account_id.eq(account_id));
+        }
+        if let Some(trigger_type) = filter.trigger_type {
+            query = query.filter(dsl::trigger_type.eq(trigger_type));
         }
 
         let limit = pagination.fetch_limit();
@@ -264,7 +285,7 @@ impl WorkspacePipelineRunRepository for PgConnection {
         &mut self,
         workspace_id: Uuid,
         pagination: CursorPagination,
-        status_filter: Option<PipelineRunStatus>,
+        filter: &RunFilter,
     ) -> PgResult<CursorPage<(WithAccountRef<WorkspacePipelineRun>, Handle)>> {
         use schema::accounts::dsl as accounts;
         use schema::workspace_pipeline_runs::dsl as runs;
@@ -280,8 +301,20 @@ impl WorkspacePipelineRunRepository for PgConnection {
                 .inner_join(accounts::accounts)
                 .filter(pipelines::workspace_id.eq(workspace_id))
                 .into_boxed();
-            if let Some(status) = status_filter {
+            if let Some(status) = filter.status {
                 query = query.filter(runs::status.eq(status));
+            }
+            if let Some(file_id) = filter.input_file_id {
+                query = query.filter(runs::input_file_id.eq(file_id));
+            }
+            if let Some(pipeline_id) = filter.pipeline_id {
+                query = query.filter(runs::pipeline_id.eq(pipeline_id));
+            }
+            if let Some(account_id) = filter.account_id {
+                query = query.filter(runs::account_id.eq(account_id));
+            }
+            if let Some(trigger_type) = filter.trigger_type {
+                query = query.filter(runs::trigger_type.eq(trigger_type));
             }
             query
         };

--- a/crates/nvisy-postgres/src/types/filtering/mod.rs
+++ b/crates/nvisy-postgres/src/types/filtering/mod.rs
@@ -3,7 +3,9 @@
 mod files;
 mod invites;
 mod members;
+mod runs;
 
 pub use files::FileFilter;
 pub use invites::InviteFilter;
 pub use members::MemberFilter;
+pub use runs::RunFilter;

--- a/crates/nvisy-postgres/src/types/filtering/runs.rs
+++ b/crates/nvisy-postgres/src/types/filtering/runs.rs
@@ -1,0 +1,88 @@
+//! Filtering options for pipeline run queries.
+
+#[cfg(feature = "schema")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::types::{PipelineRunStatus, PipelineTriggerType};
+
+/// Filter options for pipeline runs.
+///
+/// Each field narrows the result when set; unset fields impose no constraint.
+/// The owning pipeline (single-pipeline listing) and workspace scope are applied
+/// by the query itself, not carried here.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct RunFilter {
+    /// Filter by run status.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<PipelineRunStatus>,
+    /// Filter by the source file the run analyzes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_file_id: Option<Uuid>,
+    /// Filter by the owning pipeline. Ignored by the single-pipeline listing
+    /// (already scoped to one pipeline); used by the workspace-wide listing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pipeline_id: Option<Uuid>,
+    /// Filter by the account that triggered the run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_id: Option<Uuid>,
+    /// Filter by how the run was initiated (user vs system).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_type: Option<PipelineTriggerType>,
+}
+
+impl RunFilter {
+    /// Creates a new empty filter.
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Filters by run status.
+    #[inline]
+    pub fn with_status(mut self, status: PipelineRunStatus) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    /// Filters by the source file the run analyzes.
+    #[inline]
+    pub fn with_input_file_id(mut self, input_file_id: Uuid) -> Self {
+        self.input_file_id = Some(input_file_id);
+        self
+    }
+
+    /// Filters by the owning pipeline.
+    #[inline]
+    pub fn with_pipeline_id(mut self, pipeline_id: Uuid) -> Self {
+        self.pipeline_id = Some(pipeline_id);
+        self
+    }
+
+    /// Filters by the account that triggered the run.
+    #[inline]
+    pub fn with_account_id(mut self, account_id: Uuid) -> Self {
+        self.account_id = Some(account_id);
+        self
+    }
+
+    /// Filters by how the run was initiated.
+    #[inline]
+    pub fn with_trigger_type(mut self, trigger_type: PipelineTriggerType) -> Self {
+        self.trigger_type = Some(trigger_type);
+        self
+    }
+
+    /// Returns whether any filter is active.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.status.is_none()
+            && self.input_file_id.is_none()
+            && self.pipeline_id.is_none()
+            && self.account_id.is_none()
+            && self.trigger_type.is_none()
+    }
+}

--- a/crates/nvisy-postgres/src/types/mod.rs
+++ b/crates/nvisy-postgres/src/types/mod.rs
@@ -28,7 +28,7 @@ pub use enums::{
     PipelineRunStatus, PipelineStatus, PipelineTriggerType, SyncDeletionPolicy, SyncMode,
     SyncStatus, SyncTriggerType, WebhookEvent, WebhookStatus, WorkspaceRole,
 };
-pub use filtering::{FileFilter, InviteFilter, MemberFilter};
+pub use filtering::{FileFilter, InviteFilter, MemberFilter, RunFilter};
 pub use handle::{HANDLE_MAX_LENGTH, HANDLE_MIN_LENGTH, Handle, HandleError};
 pub use pagination::{Cursor, CursorPage, CursorPagination, OffsetPage, OffsetPagination};
 pub use prefixed_id::{ConnectionId, PrefixedIdError, RunId, WebhookId};

--- a/crates/nvisy-server/src/handler/pipeline_runs.rs
+++ b/crates/nvisy-server/src/handler/pipeline_runs.rs
@@ -30,7 +30,7 @@ use crate::extract::{
 };
 use crate::handler::request::{
     CreatePipelineRun, CursorPagination, PipelineDefinition, PipelinePathParams,
-    PipelineRunPathParams, WorkspaceRunsQuery,
+    PipelineRunPathParams, PipelineRunsQuery, WorkspaceRunsQuery,
 };
 use crate::handler::response::{ErrorResponse, PipelineRun, PipelineRunsPage};
 use crate::handler::utility::{SseResponse, resolve_account_ref};
@@ -232,6 +232,7 @@ async fn list_pipeline_runs(
     WorkspaceContext(workspace): WorkspaceContext,
     Path(path_params): Path<PipelinePathParams>,
     Query(pagination): Query<CursorPagination>,
+    Query(query): Query<PipelineRunsQuery>,
 ) -> Result<(StatusCode, Json<PipelineRunsPage>)> {
     tracing::debug!(target: TRACING_TARGET, "Listing pipeline runs");
 
@@ -244,7 +245,7 @@ async fn list_pipeline_runs(
     let pipeline = find_pipeline(&mut conn, workspace.id, &path_params.pipeline_slug).await?;
 
     let page = conn
-        .cursor_list_workspace_pipeline_runs(pipeline.id, pagination.into(), None)
+        .cursor_list_workspace_pipeline_runs(pipeline.id, pagination.into(), &query.into())
         .await?;
 
     tracing::debug!(
@@ -267,7 +268,10 @@ async fn list_pipeline_runs(
 
 fn list_pipeline_runs_docs(op: TransformOperation) -> TransformOperation {
     op.summary("List pipeline runs")
-        .description("Returns all runs for a specific pipeline.")
+        .description(
+            "Returns runs for a specific pipeline, most recent first, with \
+             optional status, file, trigger-account, and trigger-type filters.",
+        )
         .response::<200, Json<PipelineRunsPage>>()
         .response::<401, Json<ErrorResponse>>()
         .response::<403, Json<ErrorResponse>>()
@@ -301,7 +305,7 @@ async fn list_workspace_runs(
         .await?;
 
     let page = conn
-        .cursor_list_workspace_runs(workspace.id, pagination.into(), query.status)
+        .cursor_list_workspace_runs(workspace.id, pagination.into(), &query.into())
         .await?;
 
     tracing::debug!(
@@ -330,7 +334,8 @@ fn list_workspace_runs_docs(op: TransformOperation) -> TransformOperation {
     op.summary("List workspace runs")
         .description(
             "Returns all pipeline runs across the workspace, most recent first, \
-             with optional status and pipeline filters.",
+             with optional status, file, pipeline, trigger-account, and \
+             trigger-type filters.",
         )
         .response::<200, Json<PipelineRunsPage>>()
         .response::<401, Json<ErrorResponse>>()

--- a/crates/nvisy-server/src/handler/request/pipeline_runs.rs
+++ b/crates/nvisy-server/src/handler/request/pipeline_runs.rs
@@ -1,18 +1,69 @@
 //! Pipeline run request types (detect).
 
 use nvisy_engine::plan::ScopeParams;
-use nvisy_postgres::types::PipelineRunStatus;
+use nvisy_postgres::types::{PipelineRunStatus, PipelineTriggerType, RunFilter};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use validator::Validate;
 
 /// Query parameters for listing runs across a workspace.
+///
+/// Every field is an optional filter; unset fields impose no constraint.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceRunsQuery {
     /// Filter by run status.
     pub status: Option<PipelineRunStatus>,
+    /// Filter by the source file the run analyzes.
+    pub file_id: Option<Uuid>,
+    /// Filter by the owning pipeline.
+    pub pipeline_id: Option<Uuid>,
+    /// Filter by the account that triggered the run.
+    pub triggered_by: Option<Uuid>,
+    /// Filter by how the run was initiated (user vs system).
+    pub trigger_type: Option<PipelineTriggerType>,
+}
+
+impl From<WorkspaceRunsQuery> for RunFilter {
+    fn from(query: WorkspaceRunsQuery) -> Self {
+        RunFilter {
+            status: query.status,
+            input_file_id: query.file_id,
+            pipeline_id: query.pipeline_id,
+            account_id: query.triggered_by,
+            trigger_type: query.trigger_type,
+        }
+    }
+}
+
+/// Query parameters for listing a single pipeline's runs.
+///
+/// The pipeline is fixed by the route, so it narrows only by status, file,
+/// trigger account, and trigger type.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PipelineRunsQuery {
+    /// Filter by run status.
+    pub status: Option<PipelineRunStatus>,
+    /// Filter by the source file the run analyzes.
+    pub file_id: Option<Uuid>,
+    /// Filter by the account that triggered the run.
+    pub triggered_by: Option<Uuid>,
+    /// Filter by how the run was initiated (user vs system).
+    pub trigger_type: Option<PipelineTriggerType>,
+}
+
+impl From<PipelineRunsQuery> for RunFilter {
+    fn from(query: PipelineRunsQuery) -> Self {
+        RunFilter {
+            status: query.status,
+            input_file_id: query.file_id,
+            pipeline_id: None,
+            account_id: query.triggered_by,
+            trigger_type: query.trigger_type,
+        }
+    }
 }
 
 /// Request payload to start a run (detect) over a file.


### PR DESCRIPTION
## Summary

The run-list endpoints only filtered by `status`, and the pipeline-scoped list (`.../pipelines/{pipelineSlug}/runs/`) hardcoded `None` — so it couldn't filter at all. Add a shared `RunFilter` and thread it through both cursor queries.

### Filters

- **`GET .../pipelines/runs/`** (workspace-wide): `status`, `fileId`, `pipelineId`, `triggeredBy`, `triggerType`
- **`GET .../pipelines/{pipelineSlug}/runs/`** (pipeline-scoped): `status`, `fileId`, `triggeredBy`, `triggerType` (pipeline is fixed by the route)

The `fileId` filter answers the "find runs by file" ask from the run-dedup discussion (#222).

## Details

- New `RunFilter` in `types/filtering/runs.rs` (matches the `InviteFilter`/`FileFilter` convention), passed to `cursor_list_workspace_runs` / `cursor_list_workspace_pipeline_runs` in place of the old positional `Option<PipelineRunStatus>`.
- Two request DTOs (`WorkspaceRunsQuery`, new `PipelineRunsQuery`) map to `RunFilter` via `From`.
- Fixes the latent gap where the pipeline-scoped list couldn't filter by status.
- All filters are on indexed/enum columns — no migration.

## Testing

Full gate green (check / fmt / clippy / doc / test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)