### PR TITLE
Run file names, audit-list fix, and named query row types

### DIFF
--- a/crates/nvisy-postgres/src/query/mod.rs
+++ b/crates/nvisy-postgres/src/query/mod.rs
@@ -43,6 +43,6 @@ pub use workspace_file::WorkspaceFileRepository;
 pub use workspace_invite::WorkspaceInviteRepository;
 pub use workspace_member::WorkspaceMemberRepository;
 pub use workspace_pipeline::WorkspacePipelineRepository;
-pub use workspace_pipeline_run::WorkspacePipelineRunRepository;
+pub use workspace_pipeline_run::{PipelineRunListRow, RunFiles, WorkspacePipelineRunRepository};
 pub use workspace_policy::WorkspacePolicyRepository;
 pub use workspace_webhook::WorkspaceWebhookRepository;

--- a/crates/nvisy-postgres/src/query/mod.rs
+++ b/crates/nvisy-postgres/src/query/mod.rs
@@ -39,7 +39,7 @@ pub use workspace_activity::WorkspaceActivityRepository;
 pub use workspace_connection::WorkspaceConnectionRepository;
 pub use workspace_connection_schedule::WorkspaceConnectionScheduleRepository;
 pub use workspace_connection_sync::WorkspaceConnectionSyncRepository;
-pub use workspace_file::WorkspaceFileRepository;
+pub use workspace_file::{ExpiredFileRef, ImportedFileRef, WorkspaceFileRepository};
 pub use workspace_invite::WorkspaceInviteRepository;
 pub use workspace_member::WorkspaceMemberRepository;
 pub use workspace_pipeline::WorkspacePipelineRepository;

--- a/crates/nvisy-postgres/src/query/workspace_file.rs
+++ b/crates/nvisy-postgres/src/query/workspace_file.rs
@@ -652,11 +652,15 @@ impl WorkspaceFileRepository for PgConnection {
             None
         };
 
-        // Rebuild query for fetching items (can't reuse boxed query after count)
+        // Rebuild query for fetching items (can't reuse boxed query after count).
+        // The document-kind filter must be reapplied here too: it is what keeps
+        // audit/artifact rows out of the list, and omitting it leaks them into
+        // the results even though the count above excludes them.
         let mut query = workspace_files::table
             .inner_join(accounts::table)
             .filter(dsl::workspace_id.eq(workspace_id))
             .filter(dsl::deleted_at.is_null())
+            .filter(dsl::file_kind.eq_any(FileKind::DOCUMENTS))
             .into_boxed();
 
         // Apply trigram search filter (pg_trgm)

--- a/crates/nvisy-postgres/src/query/workspace_file.rs
+++ b/crates/nvisy-postgres/src/query/workspace_file.rs
@@ -15,6 +15,31 @@ use crate::types::{
 };
 use crate::{PgConnection, PgError, PgResult, schema};
 
+/// A live file imported from a connection, for deletion reconciliation.
+///
+/// A `source_key` no longer present in the remote listing identifies a file
+/// whose source object was removed.
+#[derive(Debug, Clone, Queryable)]
+pub struct ImportedFileRef {
+    /// The connection-side key the file was imported from.
+    pub source_key: String,
+    /// The imported file's id.
+    pub file_id: Uuid,
+    /// The imported file's object-store path.
+    pub storage_path: String,
+}
+
+/// A file whose retention window has elapsed, for the expiry sweep.
+#[derive(Debug, Clone, Queryable)]
+pub struct ExpiredFileRef {
+    /// The file's id.
+    pub id: Uuid,
+    /// The file's object-store path.
+    pub storage_path: String,
+    /// The bucket the file's object lives in.
+    pub storage_bucket: String,
+}
+
 /// Repository for workspace file database operations.
 ///
 /// Handles file lifecycle management including upload tracking,
@@ -68,24 +93,21 @@ pub trait WorkspaceFileRepository {
         connection_id: Uuid,
     ) -> impl Future<Output = PgResult<Vec<String>>> + Send;
 
-    /// Returns `(source_key, file_id, storage_path)` for each live file imported
-    /// from a connection.
-    ///
-    /// Used to reconcile deletions: a source key no longer present in the remote
-    /// listing identifies a file whose source object was removed.
+    /// Returns each live file imported from a connection, for deletion
+    /// reconciliation (a source key absent from the remote listing identifies a
+    /// removed source object).
     fn imported_files_for_connection(
         &mut self,
         connection_id: Uuid,
-    ) -> impl Future<Output = PgResult<Vec<(String, Uuid, String)>>> + Send;
+    ) -> impl Future<Output = PgResult<Vec<ImportedFileRef>>> + Send;
 
     /// Returns up to `limit` live files whose retention window has elapsed
-    /// (`expires_at < now`), as `(id, storage_path, storage_bucket)`. The
-    /// data-retention worker sweeps these, purges their objects, and soft-deletes
-    /// the rows.
+    /// (`expires_at < now`). The data-retention worker sweeps these, purges their
+    /// objects, and soft-deletes the rows.
     fn files_due_for_expiry(
         &mut self,
         limit: i64,
-    ) -> impl Future<Output = PgResult<Vec<(Uuid, String, String)>>> + Send;
+    ) -> impl Future<Output = PgResult<Vec<ExpiredFileRef>>> + Send;
 
     /// Recomputes `expires_at` for live files of `kind` in `workspace_id`,
     /// returning the number updated. Used to backfill when retention settings
@@ -304,7 +326,7 @@ impl WorkspaceFileRepository for PgConnection {
     async fn imported_files_for_connection(
         &mut self,
         connection_id: Uuid,
-    ) -> PgResult<Vec<(String, Uuid, String)>> {
+    ) -> PgResult<Vec<ImportedFileRef>> {
         use schema::{workspace_file_imports, workspace_files};
 
         let files = workspace_file_imports::table
@@ -316,14 +338,14 @@ impl WorkspaceFileRepository for PgConnection {
                 workspace_files::id,
                 workspace_files::storage_path,
             ))
-            .load::<(String, Uuid, String)>(self)
+            .load::<ImportedFileRef>(self)
             .await
             .map_err(PgError::from)?;
 
         Ok(files)
     }
 
-    async fn files_due_for_expiry(&mut self, limit: i64) -> PgResult<Vec<(Uuid, String, String)>> {
+    async fn files_due_for_expiry(&mut self, limit: i64) -> PgResult<Vec<ExpiredFileRef>> {
         use diesel::dsl::{exists, not, now};
         use schema::workspace_pipeline_runs::dsl as runs;
         use schema::{workspace_files, workspace_pipeline_runs};
@@ -361,7 +383,7 @@ impl WorkspaceFileRepository for PgConnection {
                 workspace_files::storage_bucket,
             ))
             .limit(limit)
-            .load::<(Uuid, String, String)>(self)
+            .load::<ExpiredFileRef>(self)
             .await
             .map_err(PgError::from)?;
 

--- a/crates/nvisy-postgres/src/query/workspace_pipeline_run.rs
+++ b/crates/nvisy-postgres/src/query/workspace_pipeline_run.rs
@@ -11,9 +11,36 @@ use crate::model::{
 };
 use crate::types::{
     AccountRefRow, CursorPage, CursorPagination, Handle, PipelineRunStatus, RunFilter,
-    WithAccountRef,
 };
 use crate::{PgConnection, PgError, PgResult, schema};
+
+/// Resolved display names of a run's input and output files.
+///
+/// Each is `None` when the run has no such file yet (no output before redaction)
+/// or the file has been removed (e.g. by retention).
+#[derive(Debug, Default, Clone)]
+pub struct RunFiles {
+    /// Display name of the input document the run analyzes.
+    pub input: Option<String>,
+    /// Display name of the redacted output, once the run has produced one.
+    pub output: Option<String>,
+}
+
+/// One row of a pipeline-run listing: the run plus the context a response needs
+/// to render it without follow-up lookups — the triggering account, the owning
+/// pipeline's slug, and the input file's display name (`None` if the file was
+/// removed).
+#[derive(Debug, Clone)]
+pub struct PipelineRunListRow {
+    /// The run.
+    pub run: WorkspacePipelineRun,
+    /// The account that triggered the run.
+    pub account: AccountRefRow,
+    /// Slug of the run's owning pipeline.
+    pub pipeline_slug: Handle,
+    /// Display name of the run's input document, if still present.
+    pub input_file_name: Option<String>,
+}
 
 /// Repository for workspace pipeline run database operations.
 ///
@@ -45,15 +72,15 @@ pub trait WorkspacePipelineRunRepository {
         idempotency_key: &str,
     ) -> impl Future<Output = PgResult<Option<WorkspacePipelineRun>>> + Send;
 
-    /// Lists a specific pipeline's runs with cursor pagination, each paired with
-    /// the account that triggered it. `filter` narrows by status and/or file
-    /// (its `pipeline_id` is ignored — the listing is already pipeline-scoped).
+    /// Lists a specific pipeline's runs with cursor pagination. `filter` narrows
+    /// by status and/or file (its `pipeline_id` is ignored — the listing is
+    /// already pipeline-scoped).
     fn cursor_list_workspace_pipeline_runs(
         &mut self,
         pipeline_id: Uuid,
         pagination: CursorPagination,
         filter: &RunFilter,
-    ) -> impl Future<Output = PgResult<CursorPage<WithAccountRef<WorkspacePipelineRun>>>> + Send;
+    ) -> impl Future<Output = PgResult<CursorPage<PipelineRunListRow>>> + Send;
 
     /// Lists all runs across a workspace's pipelines with cursor pagination.
     ///
@@ -68,7 +95,7 @@ pub trait WorkspacePipelineRunRepository {
         workspace_id: Uuid,
         pagination: CursorPagination,
         filter: &RunFilter,
-    ) -> impl Future<Output = PgResult<CursorPage<(WithAccountRef<WorkspacePipelineRun>, Handle)>>> + Send;
+    ) -> impl Future<Output = PgResult<CursorPage<PipelineRunListRow>>> + Send;
 
     /// Atomically claims a run for detection, transitioning it to `Analyzing`.
     ///
@@ -86,6 +113,18 @@ pub trait WorkspacePipelineRunRepository {
         run_id: Uuid,
         stale_before: jiff::Timestamp,
     ) -> impl Future<Output = PgResult<Option<WorkspacePipelineRun>>> + Send;
+
+    /// Resolves the display names of a run's input and output files.
+    ///
+    /// Two indexed lookups by id (the output only when the run has produced one);
+    /// a file removed (e.g. by retention) yields `None` for that name. Used to
+    /// name a single run's files in its response without threading a join
+    /// through the shared run lookup.
+    fn run_file_names(
+        &mut self,
+        workspace_id: Uuid,
+        run: &WorkspacePipelineRun,
+    ) -> impl Future<Output = PgResult<RunFiles>> + Send;
 
     /// Updates a workspace pipeline run with new data.
     fn update_workspace_pipeline_run(
@@ -175,9 +214,9 @@ impl WorkspacePipelineRunRepository for PgConnection {
         pipeline_id: Uuid,
         pagination: CursorPagination,
         filter: &RunFilter,
-    ) -> PgResult<CursorPage<WithAccountRef<WorkspacePipelineRun>>> {
+    ) -> PgResult<CursorPage<PipelineRunListRow>> {
         use schema::workspace_pipeline_runs::dsl;
-        use schema::{accounts, workspace_pipeline_runs};
+        use schema::{accounts, workspace_files, workspace_pipeline_runs, workspace_pipelines};
 
         // Build base query with filters. The listing is already scoped to one
         // pipeline, so `filter.pipeline_id` is not applied here.
@@ -210,9 +249,14 @@ impl WorkspacePipelineRunRepository for PgConnection {
             None
         };
 
-        // Rebuild query for fetching items
+        // Rebuild query for fetching items. Join the owning pipeline (for its
+        // slug) and the input file (to name the run's analyzed document) so a
+        // row is self-contained; a LEFT JOIN on the file tolerates one removed
+        // by retention, yielding a null name.
         let mut query = workspace_pipeline_runs::table
             .inner_join(accounts::table)
+            .inner_join(workspace_pipelines::table)
+            .left_join(workspace_files::table.on(dsl::input_file_id.eq(workspace_files::id)))
             .filter(dsl::pipeline_id.eq(pipeline_id))
             .into_boxed();
 
@@ -230,8 +274,18 @@ impl WorkspacePipelineRunRepository for PgConnection {
         }
 
         let limit = pagination.fetch_limit();
+        let selection = (
+            WorkspacePipelineRun::as_select(),
+            (
+                accounts::username,
+                accounts::display_name,
+                accounts::avatar_url,
+            ),
+            workspace_pipelines::slug,
+            workspace_files::display_name.nullable(),
+        );
 
-        let rows: Vec<(WorkspacePipelineRun, AccountRefRow)> =
+        let rows: Vec<(WorkspacePipelineRun, AccountRefRow, Handle, Option<String>)> =
             if let Some(cursor) = &pagination.after {
                 let cursor_time = jiff_diesel::Timestamp::from(cursor.timestamp);
 
@@ -241,14 +295,7 @@ impl WorkspacePipelineRunRepository for PgConnection {
                             .lt(&cursor_time)
                             .or(dsl::started_at.eq(&cursor_time).and(dsl::id.lt(cursor.id))),
                     )
-                    .select((
-                        WorkspacePipelineRun::as_select(),
-                        (
-                            accounts::username,
-                            accounts::display_name,
-                            accounts::avatar_url,
-                        ),
-                    ))
+                    .select(selection)
                     .order((dsl::started_at.desc(), dsl::id.desc()))
                     .limit(limit)
                     .load(self)
@@ -256,14 +303,7 @@ impl WorkspacePipelineRunRepository for PgConnection {
                     .map_err(PgError::from)?
             } else {
                 query
-                    .select((
-                        WorkspacePipelineRun::as_select(),
-                        (
-                            accounts::username,
-                            accounts::display_name,
-                            accounts::avatar_url,
-                        ),
-                    ))
+                    .select(selection)
                     .order((dsl::started_at.desc(), dsl::id.desc()))
                     .limit(limit)
                     .load(self)
@@ -271,13 +311,20 @@ impl WorkspacePipelineRunRepository for PgConnection {
                     .map_err(PgError::from)?
             };
 
-        let items: Vec<WithAccountRef<WorkspacePipelineRun>> = rows
+        let items = rows
             .into_iter()
-            .map(|(item, account)| WithAccountRef { item, account })
+            .map(
+                |(run, account, pipeline_slug, input_file_name)| PipelineRunListRow {
+                    run,
+                    account,
+                    pipeline_slug,
+                    input_file_name,
+                },
+            )
             .collect();
 
-        Ok(CursorPage::new(items, total, pagination.limit, |wc| {
-            (wc.item.started_at.into(), wc.item.id)
+        Ok(CursorPage::new(items, total, pagination.limit, |row| {
+            (row.run.started_at.into(), row.run.id)
         }))
     }
 
@@ -286,19 +333,23 @@ impl WorkspacePipelineRunRepository for PgConnection {
         workspace_id: Uuid,
         pagination: CursorPagination,
         filter: &RunFilter,
-    ) -> PgResult<CursorPage<(WithAccountRef<WorkspacePipelineRun>, Handle)>> {
+    ) -> PgResult<CursorPage<PipelineRunListRow>> {
         use schema::accounts::dsl as accounts;
+        use schema::workspace_files::dsl as files;
         use schema::workspace_pipeline_runs::dsl as runs;
         use schema::workspace_pipelines::dsl as pipelines;
 
         // Runs have no workspace column; scope them through the owning pipeline.
-        // The owning pipeline's slug and the triggering account are selected
-        // alongside each run so the cross-pipeline response can name its pipeline
-        // and trigger (the run is addressed by its own id).
+        // The owning pipeline's slug, the triggering account, and the input
+        // file's name are selected alongside each run so the cross-pipeline
+        // response can name its pipeline, trigger, and analyzed document without
+        // a per-row lookup. The input file is LEFT-joined so a file removed by
+        // retention yields a null name rather than dropping the run.
         let scoped = || {
             let mut query = runs::workspace_pipeline_runs
                 .inner_join(pipelines::workspace_pipelines)
                 .inner_join(accounts::accounts)
+                .left_join(files::workspace_files.on(runs::input_file_id.eq(files::id)))
                 .filter(pipelines::workspace_id.eq(workspace_id))
                 .into_boxed();
             if let Some(status) = filter.status {
@@ -340,9 +391,10 @@ impl WorkspacePipelineRunRepository for PgConnection {
                 accounts::display_name,
                 accounts::avatar_url,
             ),
+            files::display_name.nullable(),
         );
 
-        let rows: Vec<(WorkspacePipelineRun, Handle, AccountRefRow)> =
+        let rows: Vec<(WorkspacePipelineRun, Handle, AccountRefRow, Option<String>)> =
             if let Some(cursor) = &pagination.after {
                 let cursor_time = jiff_diesel::Timestamp::from(cursor.timestamp);
 
@@ -368,19 +420,21 @@ impl WorkspacePipelineRunRepository for PgConnection {
                     .map_err(PgError::from)?
             };
 
-        let items: Vec<(WithAccountRef<WorkspacePipelineRun>, Handle)> = rows
+        let items = rows
             .into_iter()
-            .map(|(item, slug, account)| (WithAccountRef { item, account }, slug))
+            .map(
+                |(run, pipeline_slug, account, input_file_name)| PipelineRunListRow {
+                    run,
+                    account,
+                    pipeline_slug,
+                    input_file_name,
+                },
+            )
             .collect();
 
-        Ok(CursorPage::new(
-            items,
-            total,
-            pagination.limit,
-            |(wc, _): &(WithAccountRef<WorkspacePipelineRun>, Handle)| {
-                (wc.item.started_at.into(), wc.item.id)
-            },
-        ))
+        Ok(CursorPage::new(items, total, pagination.limit, |row| {
+            (row.run.started_at.into(), row.run.id)
+        }))
     }
 
     async fn claim_run_for_detection(
@@ -416,6 +470,40 @@ impl WorkspacePipelineRunRepository for PgConnection {
         .map_err(PgError::from)?;
 
         Ok(claimed)
+    }
+
+    async fn run_file_names(
+        &mut self,
+        workspace_id: Uuid,
+        run: &WorkspacePipelineRun,
+    ) -> PgResult<RunFiles> {
+        use schema::workspace_files::{self, dsl};
+
+        // Select the display name only, scoped to the workspace and excluding
+        // soft-deleted files, so a file removed by retention resolves to `None`.
+        async fn name_of(
+            conn: &mut PgConnection,
+            workspace_id: Uuid,
+            file_id: Uuid,
+        ) -> PgResult<Option<String>> {
+            workspace_files::table
+                .filter(dsl::id.eq(file_id))
+                .filter(dsl::workspace_id.eq(workspace_id))
+                .filter(dsl::deleted_at.is_null())
+                .select(dsl::display_name)
+                .first::<String>(conn)
+                .await
+                .optional()
+                .map_err(PgError::from)
+        }
+
+        let input = name_of(self, workspace_id, run.input_file_id).await?;
+        let output = match run.output_file_id {
+            Some(output_file_id) => name_of(self, workspace_id, output_file_id).await?,
+            None => None,
+        };
+
+        Ok(RunFiles { input, output })
     }
 
     async fn update_workspace_pipeline_run(

--- a/crates/nvisy-server/src/handler/pipeline_runs.rs
+++ b/crates/nvisy-server/src/handler/pipeline_runs.rs
@@ -17,7 +17,7 @@ use nvisy_postgres::model::{
     NewWorkspacePipelineRun, UpdateWorkspacePipelineRun, WorkspacePipeline, WorkspacePipelineRun,
 };
 use nvisy_postgres::query::{
-    PipelineReferenceRepository, WorkspaceFileRepository, WorkspacePipelineRepository,
+    PipelineReferenceRepository, RunFiles, WorkspaceFileRepository, WorkspacePipelineRepository,
     WorkspacePipelineRunRepository,
 };
 use nvisy_postgres::types::{PipelineRunStatus, WorkspaceSettings};
@@ -93,6 +93,7 @@ async fn create_pipeline_run(
     {
         tracing::debug!(target: TRACING_TARGET, "Replaying run for idempotency key");
         let trigger = resolve_account_ref(&mut conn, existing.account_id).await?;
+        let files = conn.run_file_names(workspace.id, &existing).await?;
         return Ok((
             StatusCode::OK,
             Json(PipelineRun::from_model(
@@ -100,6 +101,7 @@ async fn create_pipeline_run(
                 pipeline.slug.clone(),
                 workspace.slug.clone(),
                 trigger,
+                files,
             )),
         ));
     }
@@ -188,6 +190,12 @@ async fn create_pipeline_run(
 
     let trigger = resolve_account_ref(&mut conn, run.account_id).await?;
 
+    // The run was just created from this file and has no output yet.
+    let files = RunFiles {
+        input: Some(file.display_name),
+        output: None,
+    };
+
     Ok((
         StatusCode::ACCEPTED,
         Json(PipelineRun::from_model(
@@ -195,6 +203,7 @@ async fn create_pipeline_run(
             pipeline.slug,
             workspace.slug,
             trigger,
+            files,
         )),
     ))
 }
@@ -254,12 +263,16 @@ async fn list_pipeline_runs(
         "Pipeline runs listed"
     );
 
-    let response = PipelineRunsPage::from_cursor_page(page, |wc| {
+    let response = PipelineRunsPage::from_cursor_page(page, |row| {
         PipelineRun::from_model(
-            wc.item,
-            pipeline.slug.clone(),
+            row.run,
+            row.pipeline_slug,
             workspace.slug.clone(),
-            wc.account.into(),
+            row.account.into(),
+            RunFiles {
+                input: row.input_file_name,
+                output: None,
+            },
         )
     });
 
@@ -316,17 +329,18 @@ async fn list_workspace_runs(
 
     Ok((
         StatusCode::OK,
-        Json(PipelineRunsPage::from_cursor_page(
-            page,
-            |(wc, pipeline_slug)| {
-                PipelineRun::from_model(
-                    wc.item,
-                    pipeline_slug,
-                    workspace.slug.clone(),
-                    wc.account.into(),
-                )
-            },
-        )),
+        Json(PipelineRunsPage::from_cursor_page(page, |row| {
+            PipelineRun::from_model(
+                row.run,
+                row.pipeline_slug,
+                workspace.slug.clone(),
+                row.account.into(),
+                RunFiles {
+                    input: row.input_file_name,
+                    output: None,
+                },
+            )
+        })),
     ))
 }
 
@@ -370,6 +384,7 @@ async fn get_pipeline_run(
         find_pipeline_run(&mut conn, workspace.id, path_params.run_id.as_uuid()).await?;
 
     let trigger = resolve_account_ref(&mut conn, run.account_id).await?;
+    let files = conn.run_file_names(workspace.id, &run).await?;
 
     tracing::debug!(target: TRACING_TARGET, "Pipeline run retrieved");
 
@@ -380,6 +395,7 @@ async fn get_pipeline_run(
             pipeline.slug,
             workspace.slug,
             trigger,
+            files,
         )),
     ))
 }
@@ -650,6 +666,7 @@ async fn redact_pipeline_run(
     );
 
     let trigger = resolve_account_ref(&mut conn, run.account_id).await?;
+    let files = conn.run_file_names(workspace.id, &run).await?;
 
     Ok((
         StatusCode::OK,
@@ -658,6 +675,7 @@ async fn redact_pipeline_run(
             pipeline.slug,
             workspace.slug,
             trigger,
+            files,
         )),
     ))
 }

--- a/crates/nvisy-server/src/handler/response/pipeline_runs.rs
+++ b/crates/nvisy-server/src/handler/response/pipeline_runs.rs
@@ -2,6 +2,7 @@
 
 use jiff::Timestamp;
 use nvisy_postgres::model::WorkspacePipelineRun as PipelineRunModel;
+use nvisy_postgres::query::RunFiles;
 use nvisy_postgres::types::{Handle, PipelineRunStatus, PipelineTriggerType, RunId};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -24,9 +25,16 @@ pub struct PipelineRun {
     pub workspace_slug: Handle,
     /// Source document this run analyzes / redacts.
     pub input_file_id: Uuid,
+    /// Display name of the source document, for showing the run without a
+    /// separate file lookup. `None` if the file was removed (e.g. by retention).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_file_name: Option<String>,
     /// Redacted document produced by the run, once it completes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_file_id: Option<Uuid>,
+    /// Display name of the redacted output, once the run completes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_file_name: Option<String>,
     /// Account that triggered the run.
     pub triggered_by: AccountRef,
     /// How the run was triggered.
@@ -53,12 +61,14 @@ pub type PipelineRunsPage = Page<PipelineRun>;
 
 impl PipelineRun {
     /// Creates a pipeline run response from the database model, the slugs of its
-    /// owning pipeline and workspace, and the triggering account.
+    /// owning pipeline and workspace, the triggering account, and the resolved
+    /// input/output file display names.
     pub fn from_model(
         run: PipelineRunModel,
         pipeline_slug: Handle,
         workspace_slug: Handle,
         triggered_by: AccountRef,
+        files: RunFiles,
     ) -> Self {
         // Surface a failure reason (written to metadata.error by the worker /
         // enqueue-failure path) as a dedicated field for a failed run.
@@ -73,7 +83,9 @@ impl PipelineRun {
             pipeline_slug,
             workspace_slug,
             input_file_id: run.input_file_id,
+            input_file_name: files.input,
             output_file_id: run.output_file_id,
+            output_file_name: files.output,
             triggered_by,
             trigger_type: run.trigger_type,
             status: run.status,

--- a/crates/nvisy-server/src/service/retention/worker.rs
+++ b/crates/nvisy-server/src/service/retention/worker.rs
@@ -79,15 +79,15 @@ impl RetentionWorker {
 
             let fetched = due.len() as i64;
             let mut expired = 0i64;
-            for (file_id, storage_path, storage_bucket) in due {
+            for file in due {
                 match self
-                    .expire_file(file_id, &storage_path, &storage_bucket)
+                    .expire_file(file.id, &file.storage_path, &file.storage_bucket)
                     .await
                 {
                     Ok(()) => expired += 1,
                     Err(err) => tracing::error!(
                         target: TRACING_TARGET,
-                        file_id = %file_id,
+                        file_id = %file.id,
                         error = %err,
                         "Failed to expire file",
                     ),

--- a/crates/nvisy-server/src/service/sync/service.rs
+++ b/crates/nvisy-server/src/service/sync/service.rs
@@ -227,14 +227,17 @@ impl ConnectionSyncService {
         };
 
         let mut removed = 0u64;
-        for (source_key, file_id, storage_path) in imported {
-            if remote_keys.contains(&source_key) {
+        for file in imported {
+            if remote_keys.contains(&file.source_key) {
                 continue;
             }
-            if let Err(err) = self.remove_vanished_file(file_id, &storage_path).await {
+            if let Err(err) = self
+                .remove_vanished_file(file.file_id, &file.storage_path)
+                .await
+            {
                 tracing::warn!(
                     target: TRACING_TARGET,
-                    key = %source_key, error = %err,
+                    key = %file.source_key, error = %err,
                     "Failed to reconcile deleted source object",
                 );
             } else {


### PR DESCRIPTION
Three related changes to the run/file query layer, one commit each.

## 1. Fix: audit/artifact files leaking into the file list

`cursor_list_workspace_files` builds its **count** and **item-fetch** queries separately; the count filtered `file_kind IN (original, redacted)` but the fetch query omitted it. So `audit` (and would-be `artifact`) rows were returned in the list even though the total count excluded them — after running detection this showed up as `analysis.audit` rows in `listFiles`. Reapplies the document-kind filter to the fetch query.

_(Read-path only; existing audit rows stop appearing as soon as the server runs this — no migration, no data change.)_

## 2. Feat: show input/output file names on runs

Runs exposed only `inputFileId`/`outputFileId` (raw UUIDs). Now the file **display names** are resolved so a run renders without a follow-up lookup:

- **listRuns** joins the input file (one `LEFT JOIN` per query) and returns its name.
- **Single-run** responses (get / create / replay / redact) resolve input **and** output names via a `run_file_names` query method (indexed lookups; output only when present).
- `PipelineRun` gains `inputFileName` / `outputFileName` (omitted when absent, e.g. a file removed by retention).

## 3. Refactor: name the query row types instead of positional tuples

- Both list queries now return a named `PipelineRunListRow { run, account, pipeline_slug, input_file_name }` instead of a growing `(WithAccountRef, Handle, Option<String>)` tuple (also clears clippy's *very complex type*).
- `imported_files_for_connection` → `Vec<ImportedFileRef { source_key, file_id, storage_path }>` and `files_due_for_expiry` → `Vec<ExpiredFileRef { id, storage_path, storage_bucket }>` — previously `(String, Uuid, String)` / `(Uuid, String, String)`, same-typed positional fields a caller could transpose. `#[derive(Queryable)]` keeps the select tuples unchanged; the retention sweep and sync-reconciliation callers now read fields by name.

## Testing

Full gate green (check / fmt / clippy / doc / test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)