### PR TITLE
Notifications: explicit mark-read, drop side effect from GET

### DIFF
--- a/crates/nvisy-postgres/src/query/account_notification.rs
+++ b/crates/nvisy-postgres/src/query/account_notification.rs
@@ -22,12 +22,6 @@ pub trait AccountNotificationRepository {
         new_notification: NewAccountNotification,
     ) -> impl Future<Output = PgResult<AccountNotification>> + Send;
 
-    /// Finds an account notification by its unique identifier.
-    fn find_account_notification_by_id(
-        &mut self,
-        notification_id: Uuid,
-    ) -> impl Future<Output = PgResult<Option<AccountNotification>>> + Send;
-
     /// Lists account notifications with offset pagination.
     ///
     /// Excludes expired notifications, ordered by creation date.
@@ -53,6 +47,18 @@ pub trait AccountNotificationRepository {
         &mut self,
         account_id: Uuid,
     ) -> impl Future<Output = PgResult<usize>> + Send;
+
+    /// Marks a single notification as read, scoped to its owning account.
+    ///
+    /// Returns `true` if a matching notification was updated. The `account_id`
+    /// filter is part of the `WHERE` clause, so a notification belonging to
+    /// another account (or a missing id) updates nothing and returns `false` —
+    /// there is no cross-account read or probe.
+    fn mark_account_notification_as_read(
+        &mut self,
+        account_id: Uuid,
+        notification_id: Uuid,
+    ) -> impl Future<Output = PgResult<bool>> + Send;
 
     /// Deletes all expired account notifications system-wide.
     ///
@@ -80,21 +86,6 @@ impl AccountNotificationRepository for PgConnection {
             .returning(AccountNotification::as_returning())
             .get_result(self)
             .await
-            .map_err(PgError::from)
-    }
-
-    async fn find_account_notification_by_id(
-        &mut self,
-        notification_id: Uuid,
-    ) -> PgResult<Option<AccountNotification>> {
-        use schema::account_notifications::{self, dsl};
-
-        account_notifications::table
-            .filter(dsl::id.eq(notification_id))
-            .select(AccountNotification::as_select())
-            .first(self)
-            .await
-            .optional()
             .map_err(PgError::from)
     }
 
@@ -194,6 +185,34 @@ impl AccountNotificationRepository for PgConnection {
         .execute(self)
         .await
         .map_err(PgError::from)
+    }
+
+    async fn mark_account_notification_as_read(
+        &mut self,
+        account_id: Uuid,
+        notification_id: Uuid,
+    ) -> PgResult<bool> {
+        use schema::account_notifications::{self, dsl};
+
+        let update_data = UpdateAccountNotification {
+            is_read: Some(true),
+            read_at: Some(Some(jiff_diesel::Timestamp::from(Timestamp::now()))),
+        };
+
+        // Scope by account in the WHERE clause: a notification owned by another
+        // account (or a missing id) matches no row, so this returns `false`
+        // without ever revealing whether the id exists.
+        let updated = diesel::update(
+            account_notifications::table
+                .filter(dsl::id.eq(notification_id))
+                .filter(dsl::account_id.eq(account_id)),
+        )
+        .set(&update_data)
+        .execute(self)
+        .await
+        .map_err(PgError::from)?;
+
+        Ok(updated > 0)
     }
 
     async fn delete_expired_account_notifications(&mut self) -> PgResult<usize> {

--- a/crates/nvisy-server/src/handler/notifications.rs
+++ b/crates/nvisy-server/src/handler/notifications.rs
@@ -1,7 +1,7 @@
 //! Notification handlers for account notification operations.
 //!
-//! This module provides handlers for listing notifications and checking
-//! unread notification status for the authenticated account.
+//! This module provides handlers for listing notifications, checking unread
+//! status, and marking notifications as read for the authenticated account.
 
 use aide::axum::ApiRouter;
 use aide::transform::TransformOperation;
@@ -10,16 +10,22 @@ use axum::http::StatusCode;
 use nvisy_postgres::PgClient;
 use nvisy_postgres::query::AccountNotificationRepository;
 
-use crate::extract::{AuthState, Json, Query};
-use crate::handler::Result;
-use crate::handler::request::CursorPagination;
-use crate::handler::response::{ErrorResponse, Notification, NotificationsPage, UnreadStatus};
+use crate::extract::{AuthState, Json, Path, Query};
+use crate::handler::request::{CursorPagination, NotificationPathParams};
+use crate::handler::response::{
+    ErrorResponse, MarkedReadStatus, Notification, NotificationsPage, UnreadStatus,
+};
+use crate::handler::{Error, Result};
 use crate::service::ServiceState;
 
 /// Tracing target for notification operations.
 const TRACING_TARGET: &str = "nvisy_server::handler::notifications";
 
-/// Lists notifications for the authenticated account and marks them as read.
+/// Lists notifications for the authenticated account.
+///
+/// A pure read: it does not change read status. The client marks notifications
+/// read explicitly via `POST /notifications/read/` (all) or
+/// `POST /notifications/{notificationId}/read/` (one).
 #[tracing::instrument(
     skip_all,
     fields(account_id = %auth_state.account_id)
@@ -37,19 +43,6 @@ async fn list_notifications(
         .cursor_list_account_notifications(auth_state.account_id, pagination.into())
         .await?;
 
-    // Mark all unread notifications as read
-    let unread_count = conn
-        .mark_all_account_notifications_as_read(auth_state.account_id)
-        .await?;
-
-    if unread_count > 0 {
-        tracing::debug!(
-            target: TRACING_TARGET,
-            unread_count,
-            "Marked notifications as read"
-        );
-    }
-
     let response = NotificationsPage::from_cursor_page(page, Notification::from_model);
 
     tracing::debug!(
@@ -64,7 +57,9 @@ async fn list_notifications(
 fn list_notifications_docs(op: TransformOperation) -> TransformOperation {
     op.summary("List notifications")
         .description(
-            "Returns all notifications for the authenticated account and marks them as read.",
+            "Returns the authenticated account's notifications, most recent \
+             first. Read-only — use POST /notifications/read/ or \
+             POST /notifications/{notificationId}/read/ to mark them read.",
         )
         .response::<200, Json<NotificationsPage>>()
         .response::<401, Json<ErrorResponse>>()
@@ -103,6 +98,77 @@ fn get_unread_status_docs(op: TransformOperation) -> TransformOperation {
         .response::<401, Json<ErrorResponse>>()
 }
 
+/// Marks all of the authenticated account's unread notifications as read.
+#[tracing::instrument(
+    skip_all,
+    fields(account_id = %auth_state.account_id)
+)]
+async fn mark_all_notifications_read(
+    State(pg_client): State<PgClient>,
+    AuthState(auth_state): AuthState,
+) -> Result<(StatusCode, Json<MarkedReadStatus>)> {
+    tracing::debug!(target: TRACING_TARGET, "Marking all notifications as read");
+
+    let mut conn = pg_client.get_connection().await?;
+
+    let marked_read = conn
+        .mark_all_account_notifications_as_read(auth_state.account_id)
+        .await? as i64;
+
+    tracing::debug!(target: TRACING_TARGET, marked_read, "Notifications marked as read");
+
+    Ok((StatusCode::OK, Json(MarkedReadStatus { marked_read })))
+}
+
+fn mark_all_notifications_read_docs(op: TransformOperation) -> TransformOperation {
+    op.summary("Mark all notifications as read")
+        .description(
+            "Marks every unread notification for the authenticated account as \
+             read and returns how many it marked.",
+        )
+        .response::<200, Json<MarkedReadStatus>>()
+        .response::<401, Json<ErrorResponse>>()
+}
+
+/// Marks a single notification as read.
+///
+/// Scoped to the authenticated account: a notification owned by another account
+/// (or a missing id) is reported as not found.
+#[tracing::instrument(
+    skip_all,
+    fields(
+        account_id = %auth_state.account_id,
+        notification_id = %path_params.notification_id,
+    )
+)]
+async fn mark_notification_read(
+    State(pg_client): State<PgClient>,
+    AuthState(auth_state): AuthState,
+    Path(path_params): Path<NotificationPathParams>,
+) -> Result<StatusCode> {
+    tracing::debug!(target: TRACING_TARGET, "Marking notification as read");
+
+    let mut conn = pg_client.get_connection().await?;
+
+    let marked = conn
+        .mark_account_notification_as_read(auth_state.account_id, path_params.notification_id)
+        .await?;
+
+    if !marked {
+        return Err(Error::not_found("notification"));
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+fn mark_notification_read_docs(op: TransformOperation) -> TransformOperation {
+    op.summary("Mark notification as read")
+        .description("Marks a single notification of the authenticated account as read.")
+        .response::<204, ()>()
+        .response::<401, Json<ErrorResponse>>()
+        .response::<404, Json<ErrorResponse>>()
+}
+
 /// Returns a [`Router`] with all notification routes.
 ///
 /// [`Router`]: axum::routing::Router
@@ -117,6 +183,17 @@ pub fn routes() -> ApiRouter<ServiceState> {
         .api_route(
             "/notifications/unread/",
             get_with(get_unread_status, get_unread_status_docs),
+        )
+        .api_route(
+            "/notifications/read/",
+            post_with(
+                mark_all_notifications_read,
+                mark_all_notifications_read_docs,
+            ),
+        )
+        .api_route(
+            "/notifications/{notificationId}/read/",
+            post_with(mark_notification_read, mark_notification_read_docs),
         )
         .with_path_items(|item| item.tag("Notifications"))
 }

--- a/crates/nvisy-server/src/handler/request/paths.rs
+++ b/crates/nvisy-server/src/handler/request/paths.rs
@@ -91,3 +91,15 @@ pub struct PipelineRunPathParams {
     /// Opaque identifier of the run.
     pub run_id: RunId,
 }
+
+/// Path parameters for notification operations.
+///
+/// The notification id is globally unique; account ownership is enforced in the
+/// query, so a notification of another account resolves to a not-found result.
+#[must_use]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NotificationPathParams {
+    /// Unique identifier of the notification.
+    pub notification_id: Uuid,
+}

--- a/crates/nvisy-server/src/handler/response/notifications.rs
+++ b/crates/nvisy-server/src/handler/response/notifications.rs
@@ -50,6 +50,14 @@ pub struct UnreadStatus {
     pub unread_count: i64,
 }
 
+/// Response type for a mark-all-read action.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkedReadStatus {
+    /// Number of notifications the request marked as read.
+    pub marked_read: i64,
+}
+
 impl Notification {
     pub fn from_model(notification: AccountNotification) -> Self {
         Self {


### PR DESCRIPTION
## Problem

`GET /notifications/` marked all notifications as read as a side effect (`list_notifications` called `mark_all_...as_read` after listing). A `GET` must be safe/idempotent — this one mutated state:

- reading the list cleared the unread badge; any cache / prefetch / retry / preview-bot did too;
- no way to *view* notifications without clearing them (polling a dropdown wiped the badge each poll);
- the `GET /unread/` count raced against `GET /notifications/` zeroing it.

## Change

Make the list a pure read and add explicit write endpoints:

| Method | Path | Behavior |
|---|---|---|
| GET | `/notifications/` | list, **read-only** |
| GET | `/notifications/unread/` | `{ unreadCount }` (unchanged) |
| POST | `/notifications/read/` | mark all read → `{ markedRead: n }` |
| POST | `/notifications/{notificationId}/read/` | mark one read → `204` (`404` if not the caller's / missing) |

## Security

- Removed the **unused, un-scoped** `find_account_notification_by_id` (looked up by id only — a latent IDOR if ever used for per-item writes).
- The new `mark_account_notification_as_read(account_id, id)` scopes by `account_id` **in the `WHERE` clause**: another account's id (or a missing one) updates 0 rows → `404`, with no read-then-write race and no way to probe whether an id exists.

## Behavior change

Clients that relied on "GET clears unread" must now call `POST /notifications/read/` explicitly. No DB migration (all columns/queries existed; added one query).

## Testing

Full gate green (check / fmt / clippy / doc / test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)